### PR TITLE
Cleanup unnecessary use of inline keyword

### DIFF
--- a/higan/component/processor/arm7tdmi/arm7tdmi.hpp
+++ b/higan/component/processor/arm7tdmi/arm7tdmi.hpp
@@ -119,10 +119,10 @@ struct ARM7TDMI {
   auto disassembleContext() -> string;
 
   struct GPR {
-    inline operator uint32_t() const { return data; }
-    inline auto operator=(const GPR& value) -> GPR& { return operator=(value.data); }
+    operator uint32_t() const { return data; }
+    auto operator=(const GPR& value) -> GPR& { return operator=(value.data); }
 
-    inline auto operator=(uint32 value) -> GPR& {
+    auto operator=(uint32 value) -> GPR& {
       data = value;
       if(modify) modify();
       return *this;
@@ -143,11 +143,11 @@ struct ARM7TDMI {
       SYS = 0x1f,  //system
     };
 
-    inline operator uint32_t() const {
+    operator uint32_t() const {
       return m << 0 | t << 5 | f << 6 | i << 7 | v << 28 | c << 29 | z << 30 | n << 31;
     }
 
-    inline auto operator=(uint32 data) -> PSR& {
+    auto operator=(uint32 data) -> PSR& {
       m = data.bit(0,4);
       t = data.bit(5);
       f = data.bit(6);

--- a/higan/component/processor/gsu/registers.hpp
+++ b/higan/component/processor/gsu/registers.hpp
@@ -2,32 +2,32 @@ struct Register {
   uint16 data = 0;
   bool modified = false;
 
-  inline operator uint() const {
+  operator uint() const {
     return data;
   }
 
-  inline auto assign(uint value) -> uint16 {
+  auto assign(uint value) -> uint16 {
     modified = true;
     return data = value;
   }
 
-  inline auto operator++() { return assign(data + 1); }
-  inline auto operator--() { return assign(data - 1); }
-  inline auto operator++(int) { uint r = data; assign(data + 1); return r; }
-  inline auto operator--(int) { uint r = data; assign(data - 1); return r; }
-  inline auto operator   = (uint i) { return assign(i); }
-  inline auto operator  |= (uint i) { return assign(data | i); }
-  inline auto operator  ^= (uint i) { return assign(data ^ i); }
-  inline auto operator  &= (uint i) { return assign(data & i); }
-  inline auto operator <<= (uint i) { return assign(data << i); }
-  inline auto operator >>= (uint i) { return assign(data >> i); }
-  inline auto operator  += (uint i) { return assign(data + i); }
-  inline auto operator  -= (uint i) { return assign(data - i); }
-  inline auto operator  *= (uint i) { return assign(data * i); }
-  inline auto operator  /= (uint i) { return assign(data / i); }
-  inline auto operator  %= (uint i) { return assign(data % i); }
+  auto operator++() { return assign(data + 1); }
+  auto operator--() { return assign(data - 1); }
+  auto operator++(int) { uint r = data; assign(data + 1); return r; }
+  auto operator--(int) { uint r = data; assign(data - 1); return r; }
+  auto operator   = (uint i) { return assign(i); }
+  auto operator  |= (uint i) { return assign(data | i); }
+  auto operator  ^= (uint i) { return assign(data ^ i); }
+  auto operator  &= (uint i) { return assign(data & i); }
+  auto operator <<= (uint i) { return assign(data << i); }
+  auto operator >>= (uint i) { return assign(data >> i); }
+  auto operator  += (uint i) { return assign(data + i); }
+  auto operator  -= (uint i) { return assign(data - i); }
+  auto operator  *= (uint i) { return assign(data * i); }
+  auto operator  /= (uint i) { return assign(data / i); }
+  auto operator  %= (uint i) { return assign(data % i); }
 
-  inline auto operator   = (const Register& value) { return assign(value); }
+  auto operator   = (const Register& value) { return assign(value); }
 
   Register() = default;
   Register(const Register&) = delete;
@@ -54,8 +54,8 @@ struct SFR {
   SFR(const SFR&) = delete;
   auto operator=(const SFR&) = delete;
 
-  inline operator uint() const { return data & 0x9f7e; }
-  inline auto& operator=(const uint value) { return data = value, *this; }
+  operator uint() const { return data & 0x9f7e; }
+  auto& operator=(const uint value) { return data = value, *this; }
 };
 
 struct SCMR {

--- a/higan/component/processor/huc6280/huc6280.hpp
+++ b/higan/component/processor/huc6280/huc6280.hpp
@@ -125,15 +125,15 @@ struct HuC6280 {
     bool v;  //overflow
     bool n;  //negative
 
-    inline operator uint8() const {
+    operator uint8() const {
       return c << 0 | z << 1 | i << 2 | d << 3 | b << 4 | t << 5 | v << 6 | n << 7;
     }
 
-    inline auto operator()() const -> uint8 {
+    auto operator()() const -> uint8 {
       return operator uint8();
     }
 
-    inline auto& operator=(uint8 data) {
+    auto& operator=(uint8 data) {
       c = data.bit(0);
       z = data.bit(1);
       i = data.bit(2);

--- a/higan/component/processor/m68k/m68k.hpp
+++ b/higan/component/processor/m68k/m68k.hpp
@@ -10,7 +10,7 @@ struct M68K {
   virtual auto read(uint1 upper, uint1 lower, uint24 address, uint16 data = 0) -> uint16 = 0;
   virtual auto write(uint1 upper, uint1 lower, uint24 address, uint16 data) -> void = 0;
 
-  inline auto ird() const -> uint16 { return r.ird; }
+  auto ird() const -> uint16 { return r.ird; }
 
   enum : bool { User, Supervisor };
   enum : uint { Byte, Word, Long };

--- a/higan/component/processor/mos6502/mos6502.hpp
+++ b/higan/component/processor/mos6502/mos6502.hpp
@@ -102,11 +102,11 @@ struct MOS6502 {
     bool v;  //overflow
     bool n;  //negative
 
-    inline operator uint() const {
+    operator uint() const {
       return c << 0 | z << 1 | i << 2 | d << 3 | v << 6 | n << 7;
     }
 
-    inline auto& operator=(uint8 data) {
+    auto& operator=(uint8 data) {
       c = data.bit(0);
       z = data.bit(1);
       i = data.bit(2);

--- a/higan/component/processor/spc700/spc700.hpp
+++ b/higan/component/processor/spc700/spc700.hpp
@@ -131,11 +131,11 @@ struct SPC700 {
     bool v;  //overflow
     bool n;  //negative
 
-    inline operator uint() const {
+    operator uint() const {
       return c << 0 | z << 1 | i << 2 | h << 3 | b << 4 | p << 5 | v << 6 | n << 7;
     }
 
-    inline auto& operator=(uint8 data) {
+    auto& operator=(uint8 data) {
       c = data.bit(0);
       z = data.bit(1);
       i = data.bit(2);

--- a/higan/component/processor/upd96050/upd96050.hpp
+++ b/higan/component/processor/upd96050/upd96050.hpp
@@ -34,11 +34,11 @@ struct uPD96050 {
   uint16 dataRAM[2048];
 
   struct Flag {
-    inline operator uint() const {
+    operator uint() const {
       return ov0 << 0 | ov1 << 1 | z << 2 | c << 3 | s0 << 4 | s1 << 5;
     }
 
-    inline auto operator=(uint16 data) -> Flag& {
+    auto operator=(uint16 data) -> Flag& {
       ov0 = data.bit(0);
       ov1 = data.bit(1);
       z   = data.bit(2);
@@ -59,13 +59,13 @@ struct uPD96050 {
   };
 
   struct Status {
-    inline operator uint() const {
+    operator uint() const {
       bool _drs = drs & !drc;  //when DRC=1, DRS=0
       return p0 << 0 | p1 << 1 | ei << 7 | sic << 8 | soc << 9 | drc << 10
            | dma << 11 | _drs << 12 | usf0 << 13 | usf1 << 14 | rqm << 15;
     }
 
-    inline auto operator=(uint16 data) -> Status& {
+    auto operator=(uint16 data) -> Status& {
       p0   = data.bit( 0);
       p1   = data.bit( 1);
       ei   = data.bit( 7);

--- a/higan/component/processor/v30mz/v30mz.hpp
+++ b/higan/component/processor/v30mz/v30mz.hpp
@@ -303,11 +303,11 @@ struct V30MZ {
       BitField<16,11> v{&data};  //overflow
       BitField<16,15> m{&data};  //mode
 
-      inline operator uint() const { return data & 0x8fd5 | 0x7002; }
-      inline auto& operator =(uint value) { return data  = value, *this; }
-      inline auto& operator&=(uint value) { return data &= value, *this; }
-      inline auto& operator^=(uint value) { return data ^= value, *this; }
-      inline auto& operator|=(uint value) { return data |= value, *this; }
+      operator uint() const { return data & 0x8fd5 | 0x7002; }
+      auto& operator =(uint value) { return data  = value, *this; }
+      auto& operator&=(uint value) { return data &= value, *this; }
+      auto& operator^=(uint value) { return data ^= value, *this; }
+      auto& operator|=(uint value) { return data |= value, *this; }
     } f;
   } r;
 };

--- a/higan/component/processor/wdc65816/wdc65816.hpp
+++ b/higan/component/processor/wdc65816/wdc65816.hpp
@@ -19,17 +19,17 @@ struct WDC65816 {
 
   virtual auto readDisassembler(uint24 addr) -> uint8 { return 0; }
 
-  inline auto irq() const -> bool { return r.irq; }
-  inline auto irq(bool line) -> void { r.irq = line; }
+  auto irq() const -> bool { return r.irq; }
+  auto irq(bool line) -> void { r.irq = line; }
 
   using r8 = uint8;
 
   struct r16 {
-    inline r16() {}
-    inline r16(uint data) : w(data) {}
-    inline r16(const r16& data) : w(data.w) {}
-    inline auto& operator=(uint data) { w = data; return *this; }
-    inline auto& operator=(const r16& data) { w = data.w; return *this; }
+    r16() {}
+    r16(uint data) : w(data) {}
+    r16(const r16& data) : w(data.w) {}
+    auto& operator=(uint data) { w = data; return *this; }
+    auto& operator=(const r16& data) { w = data.w; return *this; }
 
     uint16 w;
     BitRange<16,0, 7> l{&w};
@@ -37,11 +37,11 @@ struct WDC65816 {
   };
 
   struct r24 {
-    inline r24() {}
-    inline r24(uint data) : d(data) {}
-    inline r24(const r24& data) : d(data.d) {}
-    inline auto& operator=(uint data) { d = data; return *this; }
-    inline auto& operator=(const r24& data) { d = data.d; return *this; }
+    r24() {}
+    r24(uint data) : d(data) {}
+    r24(const r24& data) : d(data.d) {}
+    auto& operator=(uint data) { d = data; return *this; }
+    auto& operator=(const r24& data) { d = data.d; return *this; }
 
     uint24 d;
     BitRange<24, 0, 7> l{&d};
@@ -248,11 +248,11 @@ struct WDC65816 {
     bool v = 0;  //overflow
     bool n = 0;  //negative
 
-    inline operator uint() const {
+    operator uint() const {
       return c << 0 | z << 1 | i << 2 | d << 3 | x << 4 | m << 5 | v << 6 | n << 7;
     }
 
-    inline auto& operator=(uint8 data) {
+    auto& operator=(uint8 data) {
       c = data.bit(0);
       z = data.bit(1);
       i = data.bit(2);

--- a/higan/component/video/v9938/v9938.hpp
+++ b/higan/component/video/v9938/v9938.hpp
@@ -9,27 +9,27 @@ struct V9938 {
   virtual auto irq(bool line) -> void = 0;
   virtual auto frame() -> void = 0;
 
-  inline auto timing() const -> bool { return latch.timing; }
-  inline auto overscan() const -> bool { return latch.overscan; }
-  inline auto interlace() const -> bool { return latch.interlace; }
-  inline auto field() const -> bool { return latch.field; }
+  auto timing() const -> bool { return latch.timing; }
+  auto overscan() const -> bool { return latch.overscan; }
+  auto interlace() const -> bool { return latch.interlace; }
+  auto field() const -> bool { return latch.field; }
 
-  inline auto vtotal() const -> uint { return !latch.timing ? 262 : 313; }
-  inline auto vlines() const -> uint { return !latch.overscan ? 192 : 212; }
+  auto vtotal() const -> uint { return !latch.timing ? 262 : 313; }
+  auto vlines() const -> uint { return !latch.overscan ? 192 : 212; }
 
-  inline auto t1() const -> bool { return screen.mode == 0b00001; }
-  inline auto t2() const -> bool { return screen.mode == 0b01001; }
-  inline auto mc() const -> bool { return screen.mode == 0b00010; }
-  inline auto g1() const -> bool { return screen.mode == 0b00000; }
-  inline auto g2() const -> bool { return screen.mode == 0b00100; }
-  inline auto g3() const -> bool { return screen.mode == 0b01000; }
-  inline auto g4() const -> bool { return screen.mode == 0b01100; }
-  inline auto g5() const -> bool { return screen.mode == 0b10000; }
-  inline auto g6() const -> bool { return screen.mode == 0b10100; }
-  inline auto g7() const -> bool { return screen.mode == 0b11100; }
+  auto t1() const -> bool { return screen.mode == 0b00001; }
+  auto t2() const -> bool { return screen.mode == 0b01001; }
+  auto mc() const -> bool { return screen.mode == 0b00010; }
+  auto g1() const -> bool { return screen.mode == 0b00000; }
+  auto g2() const -> bool { return screen.mode == 0b00100; }
+  auto g3() const -> bool { return screen.mode == 0b01000; }
+  auto g4() const -> bool { return screen.mode == 0b01100; }
+  auto g5() const -> bool { return screen.mode == 0b10000; }
+  auto g6() const -> bool { return screen.mode == 0b10100; }
+  auto g7() const -> bool { return screen.mode == 0b11100; }
 
-  inline auto s1() const -> bool { return mc() || g1() || g2(); }
-  inline auto s2() const -> bool { return g3() || g4() || g5() || g6() || g7(); }
+  auto s1() const -> bool { return mc() || g1() || g2(); }
+  auto s2() const -> bool { return g3() || g4() || g5() || g6() || g7(); }
 
   //v9938.cpp
   auto main() -> void;

--- a/higan/cv/cartridge/cartridge.hpp
+++ b/higan/cv/cartridge/cartridge.hpp
@@ -2,9 +2,9 @@ struct Cartridge {
   Node::Port port;
   Node::Peripheral node;
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
-  inline auto region() const -> string { return information.region; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
+  auto region() const -> string { return information.region; }
 
   //cartridge.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/emulator/memory/readable.hpp
+++ b/higan/emulator/memory/readable.hpp
@@ -8,14 +8,14 @@ template<typename T>
 struct Readable {
   ~Readable() { reset(); }
 
-  inline auto reset() -> void {
+  auto reset() -> void {
     delete[] self.data;
     self.data = nullptr;
     self.size = 0;
     self.mask = 0;
   }
 
-  inline auto allocate(uint size, T fill = ~0ull) -> void {
+  auto allocate(uint size, T fill = ~0ull) -> void {
     if(!size) return reset();
     delete[] self.data;
     self.size = size;
@@ -24,13 +24,13 @@ struct Readable {
     memory::fill<T>(self.data, self.mask + 1, fill);
   }
 
-  inline auto fill(T fill = ~0ull) -> void {
+  auto fill(T fill = ~0ull) -> void {
     for(uint address : range(self.size)) {
       self.data[address] = fill;
     }
   }
 
-  inline auto load(shared_pointer<vfs::file> fp) -> void {
+  auto load(shared_pointer<vfs::file> fp) -> void {
     if(!self.size) return;
     fp->read(self.data, min(fp->size(), self.size * sizeof(T)));
     for(uint address = self.size; address <= self.mask; address++) {
@@ -38,20 +38,20 @@ struct Readable {
     }
   }
 
-  inline auto save(shared_pointer<vfs::file> fp) -> void {
+  auto save(shared_pointer<vfs::file> fp) -> void {
     if(!self.size) return;
     fp->write(self.data, self.size * sizeof(T));
   }
 
   explicit operator bool() const { return (bool)self.data; }
-  inline auto data() const -> const T* { return self.data; }
-  inline auto size() const -> uint { return self.size; }
-  inline auto mask() const -> uint { return self.mask; }
+  auto data() const -> const T* { return self.data; }
+  auto size() const -> uint { return self.size; }
+  auto mask() const -> uint { return self.mask; }
 
-  inline auto operator[](uint address) const -> T { return self.data[address & self.mask]; }
-  inline auto read(uint address) const -> T { return self.data[address & self.mask]; }
-  inline auto write(uint address, T data) const -> void {}
-  inline auto program(uint address, T data) const -> void { self.data[address & self.mask] = data; }
+  auto operator[](uint address) const -> T { return self.data[address & self.mask]; }
+  auto read(uint address) const -> T { return self.data[address & self.mask]; }
+  auto write(uint address, T data) const -> void {}
+  auto program(uint address, T data) const -> void { self.data[address & self.mask] = data; }
 
   auto begin() -> T* { return &self.data[0]; }
   auto end() -> T* { return &self.data[self.size]; }

--- a/higan/emulator/memory/writable.hpp
+++ b/higan/emulator/memory/writable.hpp
@@ -8,14 +8,14 @@ template<typename T>
 struct Writable {
   ~Writable() { reset(); }
 
-  inline auto reset() -> void {
+  auto reset() -> void {
     delete[] self.data;
     self.data = nullptr;
     self.size = 0;
     self.mask = 0;
   }
 
-  inline auto allocate(uint size, T fill = ~0ull) -> void {
+  auto allocate(uint size, T fill = ~0ull) -> void {
     if(!size) return reset();
     delete[] self.data;
     self.size = size;
@@ -24,13 +24,13 @@ struct Writable {
     memory::fill<T>(self.data, self.mask + 1, fill);
   }
 
-  inline auto fill(T fill = ~0ull) -> void {
+  auto fill(T fill = ~0ull) -> void {
     for(uint address : range(self.size)) {
       self.data[address] = fill;
     }
   }
 
-  inline auto load(shared_pointer<vfs::file> fp) -> void {
+  auto load(shared_pointer<vfs::file> fp) -> void {
     if(!self.size) return;
     fp->read(self.data, min(fp->size(), self.size * sizeof(T)));
     for(uint address = self.size; address <= self.mask; address++) {
@@ -38,22 +38,22 @@ struct Writable {
     }
   }
 
-  inline auto save(shared_pointer<vfs::file> fp) -> void {
+  auto save(shared_pointer<vfs::file> fp) -> void {
     if(!self.size) return;
     fp->write(self.data, self.size * sizeof(T));
   }
 
   explicit operator bool() const { return (bool)self.data; }
-  inline auto data() -> T* { return self.data; }
-  inline auto data() const -> const T* { return self.data; }
-  inline auto size() const -> uint { return self.size; }
-  inline auto mask() const -> uint { return self.mask; }
+  auto data() -> T* { return self.data; }
+  auto data() const -> const T* { return self.data; }
+  auto size() const -> uint { return self.size; }
+  auto mask() const -> uint { return self.mask; }
 
-  inline auto operator[](uint address) -> T& { return self.data[address & self.mask]; }
-  inline auto operator[](uint address) const -> T { return self.data[address & self.mask]; }
-  inline auto read(uint address) const -> T { return self.data[address & self.mask]; }
-  inline auto write(uint address, T data) -> void { self.data[address & self.mask] = data; }
-  inline auto program(uint address, T data) -> void { self.data[address & self.mask] = data; }
+  auto operator[](uint address) -> T& { return self.data[address & self.mask]; }
+  auto operator[](uint address) const -> T { return self.data[address & self.mask]; }
+  auto read(uint address) const -> T { return self.data[address & self.mask]; }
+  auto write(uint address, T data) -> void { self.data[address & self.mask] = data; }
+  auto program(uint address, T data) -> void { self.data[address & self.mask] = data; }
 
   auto begin() -> T* { return &self.data[0]; }
   auto end() -> T* { return &self.data[self.size]; }

--- a/higan/emulator/node/audio/stream.hpp
+++ b/higan/emulator/node/audio/stream.hpp
@@ -2,9 +2,9 @@ struct Stream : Object {
   DeclareClass(Stream, "Stream")
   using Object::Object;
 
-  inline auto channels() const -> uint { return _channels.size(); }
-  inline auto frequency() const -> double { return _frequency; }
-  inline auto resamplerFrequency() const -> double { return _resamplerFrequency; }
+  auto channels() const -> uint { return _channels.size(); }
+  auto frequency() const -> double { return _frequency; }
+  auto resamplerFrequency() const -> double { return _resamplerFrequency; }
 
   auto setChannels(uint channels) -> void;
   auto setFrequency(double frequency) -> void;

--- a/higan/emulator/node/event/event.hpp
+++ b/higan/emulator/node/event/event.hpp
@@ -5,8 +5,8 @@ struct Event : Object {
     _component = component;
   }
 
-  inline auto component() const -> string { return _component; }
-  inline auto enabled() const -> bool { return _enabled; }
+  auto component() const -> string { return _component; }
+  auto enabled() const -> bool { return _enabled; }
 
   auto setComponent(string component) -> void { _component = component; }
   auto setEnabled(bool enabled) -> void { _enabled = enabled; }

--- a/higan/emulator/node/event/instruction.hpp
+++ b/higan/emulator/node/event/instruction.hpp
@@ -5,8 +5,8 @@ struct Instruction : Event {
     setDepth(_depth);
   }
 
-  inline auto depth() const -> uint { return _depth; }
-  inline auto addressBits() const -> uint { return _addressBits; }
+  auto depth() const -> uint { return _depth; }
+  auto addressBits() const -> uint { return _addressBits; }
 
   auto setDepth(uint depth) -> void {
     _depth = depth;

--- a/higan/emulator/node/input.hpp
+++ b/higan/emulator/node/input.hpp
@@ -7,8 +7,8 @@ struct Button : Input {
   DeclareClass(Button, "Button")
   using Input::Input;
 
-  inline auto value() const -> boolean { return _value; }
-  inline auto setValue(boolean value) -> void { _value = value; }
+  auto value() const -> boolean { return _value; }
+  auto setValue(boolean value) -> void { _value = value; }
 
 protected:
   boolean _value;
@@ -18,8 +18,8 @@ struct Axis : Input {
   DeclareClass(Axis, "Axis")
   using Input::Input;
 
-  inline auto value() const -> integer { return _value; }
-  inline auto setValue(integer value) -> void { _value = value; }
+  auto value() const -> integer { return _value; }
+  auto setValue(integer value) -> void { _value = value; }
 
 protected:
   integer _value;
@@ -31,8 +31,8 @@ struct Trigger : Input {
   DeclareClass(Trigger, "Trigger")
   using Input::Input;
 
-  inline auto value() const -> integer { return _value; }
-  inline auto setValue(integer value) -> void { _value = value; }
+  auto value() const -> integer { return _value; }
+  auto setValue(integer value) -> void { _value = value; }
 
 protected:
   integer _value;
@@ -44,8 +44,8 @@ struct Rumble : Input {
   DeclareClass(Rumble, "Rumble")
   using Input::Input;
 
-  inline auto enable() const -> boolean { return _enable; }
-  inline auto setEnable(boolean enable) -> void { _enable = enable; }
+  auto enable() const -> boolean { return _enable; }
+  auto setEnable(boolean enable) -> void { _enable = enable; }
 
 protected:
   boolean _enable;

--- a/higan/emulator/node/object.hpp
+++ b/higan/emulator/node/object.hpp
@@ -13,8 +13,8 @@ struct Object : shared_pointer_this<Object> {
   Object(string name = {}) : _name(name) {}
   virtual ~Object() = default;
 
-  inline auto name() const -> string { return _name; }
-  inline auto parent() const -> shared_pointer_weak<Object> { return _parent; }
+  auto name() const -> string { return _name; }
+  auto parent() const -> shared_pointer_weak<Object> { return _parent; }
 
   auto setName(string_view name) -> void { _name = name; }
 

--- a/higan/emulator/node/peripheral.hpp
+++ b/higan/emulator/node/peripheral.hpp
@@ -2,7 +2,7 @@ struct Peripheral : Object {
   DeclareClass(Peripheral, "Peripheral")
   using Object::Object;
 
-  inline auto manifest() -> string { if(_manifest) return _manifest(); return {}; }
+  auto manifest() -> string { if(_manifest) return _manifest(); return {}; }
 
   auto setManifest(function<string()> manifest) -> void { _manifest = manifest; }
 

--- a/higan/emulator/node/port.hpp
+++ b/higan/emulator/node/port.hpp
@@ -7,12 +7,12 @@ struct Port : Object {
     });
   }
 
-  inline auto allocate() -> Node::Peripheral { if(_allocate) return _allocate(); return {}; }
-  inline auto attach(Node::Peripheral node) -> void { if(_attach) return _attach(node); }
-  inline auto detach(Node::Peripheral node) -> void { if(_detach) return _detach(node); }
-  inline auto type() const -> string { return _type; }
-  inline auto family() const -> string { return _family; }
-  inline auto hotSwappable() const -> bool { return _hotSwappable; }
+  auto allocate() -> Node::Peripheral { if(_allocate) return _allocate(); return {}; }
+  auto attach(Node::Peripheral node) -> void { if(_attach) return _attach(node); }
+  auto detach(Node::Peripheral node) -> void { if(_detach) return _detach(node); }
+  auto type() const -> string { return _type; }
+  auto family() const -> string { return _family; }
+  auto hotSwappable() const -> bool { return _hotSwappable; }
 
   auto setAllocate(function<Node::Peripheral ()> allocate) -> void { _allocate = allocate; }
   auto setAttach(function<void (Node::Peripheral)> attach) -> void { _attach = attach; }

--- a/higan/emulator/node/real-time-clock.hpp
+++ b/higan/emulator/node/real-time-clock.hpp
@@ -2,8 +2,8 @@ struct RealTimeClock : Object {
   DeclareClass(RealTimeClock, "Real Time Clock")
   using Object::Object;
 
-  inline auto update() -> void { if(_update) return _update(); }
-  inline auto timestamp() const -> uint64 { return _timestamp; }
+  auto update() -> void { if(_update) return _update(); }
+  auto timestamp() const -> uint64 { return _timestamp; }
 
   auto setUpdate(function<void ()> update) { _update = update; }
   auto setTimestamp(uint64 timestamp) -> void { _timestamp = timestamp; }

--- a/higan/emulator/node/setting.hpp
+++ b/higan/emulator/node/setting.hpp
@@ -7,7 +7,7 @@ struct Setting : Object {
   DeclareClass(Setting, "Setting")
   using Object::Object;
 
-  inline auto dynamic() const -> bool { return _dynamic; }
+  auto dynamic() const -> bool { return _dynamic; }
 
   auto setDynamic(bool dynamic) -> void {
     _dynamic = dynamic;
@@ -44,9 +44,9 @@ template<typename Cast, typename Type> struct Abstract : Setting {
     _modify = modify;
   }
 
-  inline auto modify(Type value) const -> void { if(_modify) return _modify(value); }
-  inline auto value() const -> Type { return _currentValue; }
-  inline auto latch() const -> Type { return _latchedValue; }
+  auto modify(Type value) const -> void { if(_modify) return _modify(value); }
+  auto value() const -> Type { return _currentValue; }
+  auto latch() const -> Type { return _latchedValue; }
 
   auto setModify(function<void (Type)> modify) {
     _modify = modify;

--- a/higan/emulator/node/video/screen.hpp
+++ b/higan/emulator/node/video/screen.hpp
@@ -2,21 +2,21 @@ struct Screen : Object {
   DeclareClass(Screen, "Screen")
   using Object::Object;
 
-  inline auto width() const -> uint { return _width; }
-  inline auto height() const -> uint { return _height; }
-  inline auto scaleX() const -> double { return _scaleX; }
-  inline auto scaleY() const -> double { return _scaleY; }
-  inline auto aspectX() const -> double { return _aspectX; }
-  inline auto aspectY() const -> double { return _aspectY; }
-  inline auto colors() const -> uint { return _colors; }
+  auto width() const -> uint { return _width; }
+  auto height() const -> uint { return _height; }
+  auto scaleX() const -> double { return _scaleX; }
+  auto scaleY() const -> double { return _scaleY; }
+  auto aspectX() const -> double { return _aspectX; }
+  auto aspectY() const -> double { return _aspectY; }
+  auto colors() const -> uint { return _colors; }
 
-  inline auto saturation() const -> double { return _saturation; }
-  inline auto gamma() const -> double { return _gamma; }
-  inline auto luminance() const -> double { return _luminance; }
+  auto saturation() const -> double { return _saturation; }
+  auto gamma() const -> double { return _gamma; }
+  auto luminance() const -> double { return _luminance; }
 
-  inline auto colorBleed() const -> bool { return _colorBleed; }
-  inline auto interframeBlending() const -> bool { return _interframeBlending; }
-  inline auto rotation() const -> uint { return _rotation; }
+  auto colorBleed() const -> bool { return _colorBleed; }
+  auto interframeBlending() const -> bool { return _interframeBlending; }
+  auto rotation() const -> uint { return _rotation; }
 
   auto resetPalette() -> void;
   auto resetSprites() -> void;

--- a/higan/emulator/node/video/sprite.hpp
+++ b/higan/emulator/node/video/sprite.hpp
@@ -2,12 +2,12 @@ struct Sprite : Object {
   DeclareClass(Sprite, "Sprite")
   using Object::Object;
 
-  inline auto visible() const -> bool { return _visible; }
-  inline auto x() const -> uint { return _x; }
-  inline auto y() const -> uint { return _y; }
-  inline auto width() const -> uint { return _width; }
-  inline auto height() const -> uint { return _height; }
-  inline auto image() const -> const uint32* { return _pixels.data(); }
+  auto visible() const -> bool { return _visible; }
+  auto x() const -> uint { return _x; }
+  auto y() const -> uint { return _y; }
+  auto width() const -> uint { return _width; }
+  auto height() const -> uint { return _height; }
+  auto image() const -> const uint32* { return _pixels.data(); }
 
   auto setVisible(bool visible) -> void;
   auto setPosition(uint x, uint y) -> void;

--- a/higan/emulator/scheduler/thread.hpp
+++ b/higan/emulator/scheduler/thread.hpp
@@ -17,7 +17,7 @@ struct Thread {
   auto operator=(const Thread&) = delete;
   inline virtual ~Thread();
 
-  inline explicit operator bool() const { return _handle; }
+  explicit operator bool() const { return _handle; }
   inline auto active() const -> bool;
   inline auto handle() const -> cothread_t;
   inline auto frequency() const -> uintmax;

--- a/higan/fc/apu/apu.hpp
+++ b/higan/fc/apu/apu.hpp
@@ -2,7 +2,7 @@ struct APU : Thread {
   Node::Component node;
   Node::Stream stream;
 
-  inline auto rate() const -> uint { return Region::PAL() ? 16 : 12; }
+  auto rate() const -> uint { return Region::PAL() ? 16 : 12; }
 
   //apu.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/fc/cartridge/board/board.hpp
+++ b/higan/fc/cartridge/board/board.hpp
@@ -1,8 +1,8 @@
 struct Board {
   struct Memory {
-    inline Memory(uint8_t* data, uint size) : data(data), size(size) {}
-    inline Memory() : data(nullptr), size(0u), writable(false) {}
-    inline ~Memory() { if(data) delete[] data; }
+    Memory(uint8_t* data, uint size) : data(data), size(size) {}
+    Memory() : data(nullptr), size(0u), writable(false) {}
+    ~Memory() { if(data) delete[] data; }
 
     inline auto read(uint addr) const -> uint8;
     inline auto write(uint addr, uint8 data) -> void;

--- a/higan/fc/cartridge/cartridge.hpp
+++ b/higan/fc/cartridge/cartridge.hpp
@@ -5,10 +5,10 @@ struct Cartridge : Thread {
   Node::Port port;
   Node::Peripheral node;
 
-  inline auto rate() const -> uint { return Region::PAL() ? 16 : 12; }
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
-  inline auto region() const -> string { return information.region; }
+  auto rate() const -> uint { return Region::PAL() ? 16 : 12; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
+  auto region() const -> string { return information.region; }
 
   //cartridge.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/fc/cpu/cpu.hpp
+++ b/higan/fc/cpu/cpu.hpp
@@ -3,7 +3,7 @@ struct CPU : MOS6502, Thread {
   Node::Instruction eventInstruction;
   Node::Notification eventInterrupt;
 
-  inline auto rate() const -> uint { return Region::PAL() ? 16 : 12; }
+  auto rate() const -> uint { return Region::PAL() ? 16 : 12; }
 
   //cpu.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/fc/fds/fds.hpp
+++ b/higan/fc/fds/fds.hpp
@@ -10,8 +10,8 @@ struct FDS {
   Node::String state;
   uint1 present;
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
 
   struct Disk {
     Memory::Writable<uint8> sideA;

--- a/higan/fc/ppu/ppu.hpp
+++ b/higan/fc/ppu/ppu.hpp
@@ -4,8 +4,8 @@ struct PPU : Thread {
   Node::String region;
   Node::Boolean colorEmulation;
 
-  inline auto rate() const -> uint { return Region::PAL() ? 5 : 4; }
-  inline auto vlines() const -> uint { return Region::PAL() ? 312 : 262; }
+  auto rate() const -> uint { return Region::PAL() ? 5 : 4; }
+  auto vlines() const -> uint { return Region::PAL() ? 312 : 262; }
 
   //ppu.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/fc/system/system.hpp
+++ b/higan/fc/system/system.hpp
@@ -16,8 +16,8 @@ struct System {
 
   enum class Region : uint { NTSCJ, NTSCU, PAL };
 
-  inline auto region() const -> Region { return information.region; }
-  inline auto frequency() const -> double { return information.frequency; }
+  auto region() const -> Region { return information.region; }
+  auto frequency() const -> double { return information.frequency; }
 
   //system.cpp
   auto run() -> void;

--- a/higan/gb/cartridge/cartridge.hpp
+++ b/higan/gb/cartridge/cartridge.hpp
@@ -2,8 +2,8 @@ struct Cartridge : Thread {
   Node::Port port;
   Node::Peripheral node;
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
 
   //cartridge.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/gb/cpu/cpu.hpp
+++ b/higan/gb/cpu/cpu.hpp
@@ -12,8 +12,8 @@ struct CPU : SM83, Thread {
     /* 4 */ Joypad,
   };};
 
-  inline auto lowSpeed()  const -> bool { return status.speedDouble == 0; }
-  inline auto highSpeed() const -> bool { return status.speedDouble == 1; }
+  auto lowSpeed()  const -> bool { return status.speedDouble == 0; }
+  auto highSpeed() const -> bool { return status.speedDouble == 1; }
 
   //cpu.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/gb/system/system.hpp
+++ b/higan/gb/system/system.hpp
@@ -31,8 +31,8 @@ struct System {
   };
   higan::Memory::Readable<uint8> bootROM;  //todo: no higan:: prefix
 
-  inline auto model() const -> Model { return information.model; }
-  inline auto clocksExecuted() const -> uint { return information.clocksExecuted; }
+  auto model() const -> Model { return information.model; }
+  auto clocksExecuted() const -> uint { return information.clocksExecuted; }
 
   //system.cpp
   auto run() -> void;

--- a/higan/gba/apu/apu.hpp
+++ b/higan/gba/apu/apu.hpp
@@ -37,7 +37,7 @@ struct APU : Thread, IO {
   };
 
   struct Envelope {
-    inline auto dacEnable() const -> bool { return volume || direction; }
+    auto dacEnable() const -> bool { return volume || direction; }
 
     uint3 frequency;
     uint1 direction;

--- a/higan/gba/cartridge/cartridge.hpp
+++ b/higan/gba/cartridge/cartridge.hpp
@@ -4,8 +4,8 @@ struct Cartridge {
 
   #include "memory.hpp"
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
 
   //cartridge.cpp
   Cartridge();

--- a/higan/gba/cpu/cpu.hpp
+++ b/higan/gba/cpu/cpu.hpp
@@ -19,9 +19,9 @@ struct CPU : ARM7TDMI, Thread, IO {
     Cartridge    = 0x2000,
   };};
 
-  inline auto clock() const -> uint { return context.clock; }
-  inline auto halted() const -> bool { return context.halted; }
-  inline auto stopped() const -> bool { return context.stopped; }
+  auto clock() const -> uint { return context.clock; }
+  auto halted() const -> bool { return context.halted; }
+  auto stopped() const -> bool { return context.stopped; }
 
   //cpu.cpp
   auto load(Node::Object, Node::Object) -> void;
@@ -69,8 +69,8 @@ struct CPU : ARM7TDMI, Thread, IO {
 
 //private:
   struct uintVN {
-    inline auto operator()() const -> uint32 { return data & mask; }
-    inline auto setBits(uint bits) -> void { mask = (1 << bits) - 1; }
+    auto operator()() const -> uint32 { return data & mask; }
+    auto setBits(uint bits) -> void { mask = (1 << bits) - 1; }
 
     uint32 data;
     uint32 mask;
@@ -195,8 +195,8 @@ struct CPU : ARM7TDMI, Thread, IO {
   } memory;
 
   struct {
-    inline auto empty() const { return addr == load; }
-    inline auto full() const { return load - addr == 16; }
+    auto empty() const { return addr == load; }
+    auto full() const { return load - addr == 16; }
 
     uint16 slot[8];
     uint32 addr;       //read location of slot buffer

--- a/higan/gba/system/system.hpp
+++ b/higan/gba/system/system.hpp
@@ -31,8 +31,8 @@ struct System {
 
   enum class Model : uint { GameBoyAdvance, GameBoyPlayer };
 
-  inline auto model() const -> Model { return information.model; }
-  inline auto frequency() const -> double { return 16 * 1024 * 1024; }
+  auto model() const -> Model { return information.model; }
+  auto frequency() const -> double { return 16 * 1024 * 1024; }
 
   //system.cpp
   auto run() -> void;

--- a/higan/md/cartridge/cartridge.hpp
+++ b/higan/md/cartridge/cartridge.hpp
@@ -7,10 +7,10 @@ struct Cartridge {
   Memory::Writable<uint16> wram;  //16-bit save RAM
   Memory::Writable< uint8> bram;  // 8-bit save RAM
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
-  inline auto regions() const -> vector<string> { return information.regions; }
-  inline auto bootable() const -> boolean { return information.bootable; }  //CART_IN line
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
+  auto regions() const -> vector<string> { return information.regions; }
+  auto bootable() const -> boolean { return information.bootable; }  //CART_IN line
 
   //cartridge.cpp
   Cartridge() = default;

--- a/higan/md/expansion/expansion.hpp
+++ b/higan/md/expansion/expansion.hpp
@@ -6,9 +6,9 @@ struct Expansion {
   Node::Port port;
   Node::Peripheral node;
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
-  inline auto regions() const -> vector<string> { return information.regions; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
+  auto regions() const -> vector<string> { return information.regions; }
 
   auto load(Node::Object, Node::Object) -> void;
   auto unload() -> void;

--- a/higan/md/mcd/mcd.hpp
+++ b/higan/md/mcd/mcd.hpp
@@ -12,8 +12,8 @@ struct MCD : M68K, Thread {
   Memory::Writable<uint16> wram;  //work RAM
   Memory::Writable< uint8> bram;  //backup RAM
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
 
   //mcd.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/md/system/system.hpp
+++ b/higan/md/system/system.hpp
@@ -16,9 +16,9 @@ struct System {
 
   enum class Region : uint { NTSCJ, NTSCU, PAL };
 
-  inline auto region() const -> Region { return information.region; }
-  inline auto megaCD() const -> bool { return information.megaCD; }
-  inline auto frequency() const -> double { return information.frequency; }
+  auto region() const -> Region { return information.region; }
+  auto megaCD() const -> bool { return information.megaCD; }
+  auto frequency() const -> double { return information.frequency; }
 
   auto run() -> void;
 

--- a/higan/md/vdp/vdp.hpp
+++ b/higan/md/vdp/vdp.hpp
@@ -57,8 +57,8 @@ struct VDP : Thread {
   auto outputPixel(uint32 color) -> void;
 
   struct Pixel {
-    inline auto above() const -> bool { return priority == 1 && color; }
-    inline auto below() const -> bool { return priority == 0 && color; }
+    auto above() const -> bool { return priority == 1 && color; }
+    auto below() const -> bool { return priority == 0 && color; }
 
     uint6 color;
     uint1 priority;

--- a/higan/ms/cartridge/cartridge.hpp
+++ b/higan/ms/cartridge/cartridge.hpp
@@ -2,9 +2,9 @@ struct Cartridge {
   Node::Port port;
   Node::Peripheral node;
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
-  inline auto region() const -> string { return information.region; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
+  auto region() const -> string { return information.region; }
 
   //cartridge.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/ms/system/system.hpp
+++ b/higan/ms/system/system.hpp
@@ -32,9 +32,9 @@ struct System {
   enum class Model : uint { MasterSystem, GameGear };
   enum class Region : uint { NTSC, PAL };
 
-  inline auto model() const -> Model { return information.model; }
-  inline auto region() const -> Region { return information.region; }
-  inline auto colorburst() const -> double { return information.colorburst; }
+  auto model() const -> Model { return information.model; }
+  auto region() const -> Region { return information.region; }
+  auto colorburst() const -> double { return information.colorburst; }
 
   //system.cpp
   auto run() -> void;

--- a/higan/msx/cartridge/cartridge.hpp
+++ b/higan/msx/cartridge/cartridge.hpp
@@ -2,9 +2,9 @@ struct Cartridge {
   Node::Port port;
   Node::Peripheral node;
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
-  inline auto region() const -> string { return information.region; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
+  auto region() const -> string { return information.region; }
 
   //cartridge.cpp
   Cartridge(string_view name);

--- a/higan/msx/system/system.hpp
+++ b/higan/msx/system/system.hpp
@@ -10,9 +10,9 @@ struct System {
   enum class Model : uint { MSX, MSX2 };
   enum class Region : uint { NTSC, PAL };
 
-  inline auto model() const -> Model { return information.model; }
-  inline auto region() const -> Region { return information.region; }
-  inline auto colorburst() const -> double { return information.colorburst; }
+  auto model() const -> Model { return information.model; }
+  auto region() const -> Region { return information.region; }
+  auto colorburst() const -> double { return information.colorburst; }
 
   //system.cpp
   auto run() -> void;

--- a/higan/ngp/cartridge/cartridge.hpp
+++ b/higan/ngp/cartridge/cartridge.hpp
@@ -6,8 +6,8 @@ struct Cartridge {
 
   Flash flash[2];
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
 
   //cartridge.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/ngp/cpu/cpu.hpp
+++ b/higan/ngp/cpu/cpu.hpp
@@ -16,7 +16,7 @@ struct CPU : TLCS900H, Thread {
   //palette, resulting in incorrect colors. . I am not certain how, but the NGPC
   //blocks this write command, so I attempt to simulate that here.
   //VPU::write(uint24, uint8) calls this function.
-  inline auto privilegedMode() const -> bool {
+  auto privilegedMode() const -> bool {
     return r.pc.l.l0 >= 0xff0000;  //may also be r.rfp == 3
   }
 
@@ -124,14 +124,14 @@ struct CPU : TLCS900H, Thread {
 
   //ports.cpp
   struct PortFlow {
-    inline auto readable() const { return flow == 0; }  //in
-    inline auto writable() const { return flow == 1; }  //out
+    auto readable() const { return flow == 0; }  //in
+    auto writable() const { return flow == 1; }  //out
     uint1 flow;
   };
 
   struct PortMode {
-    inline auto internal() const { return mode == 0; }  //port
-    inline auto external() const { return mode == 1; }  //timer, etc
+    auto internal() const { return mode == 0; }  //port
+    auto external() const { return mode == 1; }  //timer, etc
     uint1 mode;
   };
 

--- a/higan/ngp/system/system.hpp
+++ b/higan/ngp/system/system.hpp
@@ -29,8 +29,8 @@ struct System {
   enum class Model : uint { NeoGeoPocket, NeoGeoPocketColor };
   Memory::Readable<uint8> bios;
 
-  inline auto model() const -> Model { return information.model; }
-  inline auto frequency() const -> double { return 6'144'000; }
+  auto model() const -> Model { return information.model; }
+  auto frequency() const -> double { return 6'144'000; }
 
   //system.cpp
   auto run() -> void;

--- a/higan/pce/cartridge/cartridge.hpp
+++ b/higan/pce/cartridge/cartridge.hpp
@@ -4,8 +4,8 @@ struct Cartridge {
   Node::Port port;
   Node::Peripheral node;
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
 
   //cartridge.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/pce/cpu/cpu.hpp
+++ b/higan/pce/cpu/cpu.hpp
@@ -51,7 +51,7 @@ private:
   } reset;
 
   struct Timer {
-    inline auto irqLine() const { return line; }
+    auto irqLine() const { return line; }
 
     uint1 line;
     uint1 enable;

--- a/higan/pce/pcd/pcd.hpp
+++ b/higan/pce/pcd/pcd.hpp
@@ -10,8 +10,8 @@ struct PCD : Thread {
 
   static auto Present() -> bool { return true; }
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
 
   //pcd.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/pce/system/system.hpp
+++ b/higan/pce/system/system.hpp
@@ -3,8 +3,8 @@ struct System {
 
   enum class Model : uint { PCEngine, SuperGrafx };
 
-  inline auto model() const -> Model { return information.model; }
-  inline auto colorburst() const -> double { return information.colorburst; }
+  auto model() const -> Model { return information.model; }
+  auto colorburst() const -> double { return information.colorburst; }
 
   //system.cpp
   auto run() -> void;

--- a/higan/pce/vdp-performance/vce.hpp
+++ b/higan/pce/vdp-performance/vce.hpp
@@ -1,8 +1,8 @@
 //Hudson Soft HuC6260: Video Color Encoder
 
 struct VCE {
-  inline auto clock() const -> uint { return io.clock; }
-  inline auto width() const -> uint { return io.clock == 4 ? 256 : io.clock == 3 ? 344 : 512; }
+  auto clock() const -> uint { return io.clock; }
+  auto width() const -> uint { return io.clock == 4 ? 256 : io.clock == 3 ? 344 : 512; }
 
   //vce.cpp
   auto read(uint3 address) -> uint8;

--- a/higan/pce/vdp-performance/vdc.hpp
+++ b/higan/pce/vdp-performance/vdc.hpp
@@ -1,8 +1,8 @@
 //Hudson Soft HuC6270: Video Display Controller
 
 struct VDC {
-  inline auto burstMode() const -> bool { return latch.burstMode || timing.vstate != VDW; }
-  inline auto irqLine() const -> bool { return irq.line; }
+  auto burstMode() const -> bool { return latch.burstMode || timing.vstate != VDW; }
+  auto irqLine() const -> bool { return irq.line; }
 
   //vdc.cpp
   auto hsync() -> void;

--- a/higan/pce/vdp-performance/vdp.hpp
+++ b/higan/pce/vdp-performance/vdp.hpp
@@ -6,7 +6,7 @@ struct VDP : Thread {
   Node::Component node;
   Node::Screen screen;
 
-  inline auto irqLine() const -> bool { return vdc0.irqLine() | vdc1.irqLine(); }
+  auto irqLine() const -> bool { return vdc0.irqLine() | vdc1.irqLine(); }
 
   //vdp.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/pce/vdp/vce.hpp
+++ b/higan/pce/vdp/vce.hpp
@@ -1,7 +1,7 @@
 //Hudson Soft HuC6260: Video Color Encoder
 
 struct VCE {
-  inline auto clock() const -> uint { return io.clock; }
+  auto clock() const -> uint { return io.clock; }
 
   //vce.cpp
   auto read(uint3 address) -> uint8;

--- a/higan/pce/vdp/vdc.hpp
+++ b/higan/pce/vdp/vdc.hpp
@@ -1,9 +1,9 @@
 //Hudson Soft HuC6270: Video Display Controller
 
 struct VDC {
-  inline auto bus() const -> uint9 { return output; }
-  inline auto burstMode() const -> bool { return latch.burstMode || timing.vstate != VDW; }
-  inline auto irqLine() const -> bool { return irq.line; }
+  auto bus() const -> uint9 { return output; }
+  auto burstMode() const -> bool { return latch.burstMode || timing.vstate != VDW; }
+  auto irqLine() const -> bool { return irq.line; }
 
   //vdc.cpp
   auto hsync() -> void;

--- a/higan/pce/vdp/vdp.hpp
+++ b/higan/pce/vdp/vdp.hpp
@@ -9,7 +9,7 @@ struct VDP : Thread {
   Node::Component node;
   Node::Screen screen;
 
-  inline auto irqLine() const -> bool { return vdc0.irqLine() | vdc1.irqLine(); }
+  auto irqLine() const -> bool { return vdc0.irqLine() | vdc1.irqLine(); }
 
   //vdp.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/sfc/cpu/cpu.hpp
+++ b/higan/sfc/cpu/cpu.hpp
@@ -5,8 +5,8 @@ struct CPU : WDC65816, Thread, PPUcounter {
   Node::Notification eventInterrupt;
 
   inline auto interruptPending() const -> bool override { return status.interruptPending; }
-  inline auto pio() const -> uint8 { return io.pio; }
-  inline auto refresh() const -> bool { return status.dramRefresh == 1; }
+  auto pio() const -> uint8 { return io.pio; }
+  auto refresh() const -> bool { return status.dramRefresh == 1; }
   inline auto synchronizing() const -> bool override { return scheduler.synchronizing(); }
 
   //cpu.cpp

--- a/higan/sfc/dsp/dsp.hpp
+++ b/higan/sfc/dsp/dsp.hpp
@@ -7,7 +7,7 @@ struct DSP : Thread {
   uint8 apuram[64 * 1024];
   uint8 registers[128];
 
-  inline auto mute() const -> bool { return master.mute; }
+  auto mute() const -> bool { return master.mute; }
 
   //dsp.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/sfc/memory/memory.hpp
+++ b/higan/sfc/memory/memory.hpp
@@ -1,6 +1,6 @@
 struct AbstractMemory {
   virtual ~AbstractMemory() { reset(); }
-  inline explicit operator bool() const { return size() > 0; }
+  explicit operator bool() const { return size() > 0; }
 
   virtual auto reset() -> void {}
   virtual auto allocate(uint, uint8 = 0xff) -> void {}

--- a/higan/sfc/memory/protectable.hpp
+++ b/higan/sfc/memory/protectable.hpp
@@ -11,11 +11,11 @@ struct ProtectableMemory : AbstractMemory {
     for(uint address : range(size)) self.data[address] = fill;
   }
 
-  inline auto load(shared_pointer<vfs::file> fp) -> void {
+  auto load(shared_pointer<vfs::file> fp) -> void {
     fp->read(self.data, min(fp->size(), self.size));
   }
 
-  inline auto save(shared_pointer<vfs::file> fp) -> void {
+  auto save(shared_pointer<vfs::file> fp) -> void {
     fp->write(self.data, self.size);
   }
 
@@ -27,11 +27,11 @@ struct ProtectableMemory : AbstractMemory {
     return self.size;
   }
 
-  inline auto writable() const -> bool {
+  auto writable() const -> bool {
     return self.writable;
   }
 
-  inline auto writable(bool writable) -> void {
+  auto writable(bool writable) -> void {
     self.writable = writable;
   }
 
@@ -44,7 +44,7 @@ struct ProtectableMemory : AbstractMemory {
     self.data[address] = data;
   }
 
-  inline auto operator[](uint24 address) const -> uint8 {
+  auto operator[](uint24 address) const -> uint8 {
     return self.data[address];
   }
 

--- a/higan/sfc/memory/readable.hpp
+++ b/higan/sfc/memory/readable.hpp
@@ -11,11 +11,11 @@ struct ReadableMemory : AbstractMemory {
     for(uint address : range(size)) self.data[address] = fill;
   }
 
-  inline auto load(shared_pointer<vfs::file> fp) -> void {
+  auto load(shared_pointer<vfs::file> fp) -> void {
     fp->read(self.data, min(fp->size(), self.size));
   }
 
-  inline auto save(shared_pointer<vfs::file> fp) -> void {
+  auto save(shared_pointer<vfs::file> fp) -> void {
     fp->write(self.data, self.size);
   }
 
@@ -34,7 +34,7 @@ struct ReadableMemory : AbstractMemory {
   inline auto write(uint24 address, uint8 data) -> void override {
   }
 
-  inline auto operator[](uint24 address) const -> uint8 {
+  auto operator[](uint24 address) const -> uint8 {
     return self.data[address];
   }
 

--- a/higan/sfc/memory/writable.hpp
+++ b/higan/sfc/memory/writable.hpp
@@ -11,11 +11,11 @@ struct WritableMemory : AbstractMemory {
     for(uint address : range(size)) self.data[address] = fill;
   }
 
-  inline auto load(shared_pointer<vfs::file> fp) -> void {
+  auto load(shared_pointer<vfs::file> fp) -> void {
     fp->read(self.data, min(fp->size(), self.size));
   }
 
-  inline auto save(shared_pointer<vfs::file> fp) -> void {
+  auto save(shared_pointer<vfs::file> fp) -> void {
     fp->write(self.data, self.size);
   }
 
@@ -35,7 +35,7 @@ struct WritableMemory : AbstractMemory {
     self.data[address] = data;
   }
 
-  inline auto operator[](uint24 address) -> uint8& {
+  auto operator[](uint24 address) -> uint8& {
     return self.data[address];
   }
 

--- a/higan/sfc/ppu-performance/ppu.hpp
+++ b/higan/sfc/ppu-performance/ppu.hpp
@@ -4,10 +4,10 @@ struct PPU : Thread, PPUcounter {
   Node::String region;
   Node::Boolean colorEmulation;
 
-  inline auto hires() const -> bool { return io.pseudoHires || io.bgMode == 5 || io.bgMode == 6; }
-  inline auto interlace() const -> bool { return state.interlace; }
-  inline auto overscan() const -> bool { return state.overscan; }
-  inline auto vdisp() const -> uint { return state.vdisp; }
+  auto hires() const -> bool { return io.pseudoHires || io.bgMode == 5 || io.bgMode == 6; }
+  auto interlace() const -> bool { return state.interlace; }
+  auto overscan() const -> bool { return state.overscan; }
+  auto vdisp() const -> uint { return state.vdisp; }
 
   //ppu.cpp
   auto load(Node::Object parent, Node::Object from) -> void;
@@ -50,7 +50,7 @@ private:
   } ppu1, ppu2;
 
   struct VRAM {
-    inline auto& operator[](uint address) { return data[address & mask]; }
+    auto& operator[](uint address) { return data[address & mask]; }
     uint16 data[64_KiB];
     uint16 mask = 0x7fff;
     uint16 address;

--- a/higan/sfc/ppu/ppu.hpp
+++ b/higan/sfc/ppu/ppu.hpp
@@ -11,9 +11,9 @@ struct PPU : Thread, PPUcounter {
   Node::Boolean colorEmulation;
   Node::Boolean colorBleed;
 
-  inline auto interlace() const -> bool { return self.interlace; }
-  inline auto overscan() const -> bool { return self.overscan; }
-  inline auto vdisp() const -> uint { return self.vdisp; }
+  auto interlace() const -> bool { return self.interlace; }
+  auto overscan() const -> bool { return self.overscan; }
+  auto vdisp() const -> uint { return self.vdisp; }
 
   //ppu.cpp
   auto load(Node::Object parent, Node::Object from) -> void;

--- a/higan/sfc/slot/bsmemory/bsmemory.hpp
+++ b/higan/sfc/slot/bsmemory/bsmemory.hpp
@@ -20,11 +20,11 @@ struct BSMemory : Thread {
   Node::Peripheral node;
   uint ROM = 1;
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
-  inline auto size() const -> uint { return memory.size(); }
-  inline auto writable() const { return pin.writable; }
-  inline auto writable(bool writable) { pin.writable = !ROM && writable; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
+  auto size() const -> uint { return memory.size(); }
+  auto writable() const { return pin.writable; }
+  auto writable(bool writable) { pin.writable = !ROM && writable; }
 
   //bsmemory.cpp
   auto load(Node::Peripheral, Node::Peripheral) -> void;

--- a/higan/sfc/slot/sufamiturbo/sufamiturbo.hpp
+++ b/higan/sfc/slot/sufamiturbo/sufamiturbo.hpp
@@ -2,8 +2,8 @@ struct SufamiTurboCartridge {
   Node::Port port;
   Node::Peripheral node;
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
 
   //sufamiturbo.cpp
   auto load(Node::Peripheral, Node::Peripheral) -> void;

--- a/higan/sfc/system/system.hpp
+++ b/higan/sfc/system/system.hpp
@@ -15,9 +15,9 @@ struct System {
 
   enum class Region : uint { NTSC, PAL };
 
-  inline auto region() const -> Region { return information.region; }
-  inline auto cpuFrequency() const -> double { return information.cpuFrequency; }
-  inline auto apuFrequency() const -> double { return information.apuFrequency; }
+  auto region() const -> Region { return information.region; }
+  auto cpuFrequency() const -> double { return information.cpuFrequency; }
+  auto apuFrequency() const -> double { return information.apuFrequency; }
 
   auto run() -> void;
 

--- a/higan/sg/cartridge/cartridge.hpp
+++ b/higan/sg/cartridge/cartridge.hpp
@@ -2,9 +2,9 @@ struct Cartridge {
   Node::Port port;
   Node::Peripheral node;
 
-  inline auto manifest() const -> string { return information.manifest; }
-  inline auto name() const -> string { return information.name; }
-  inline auto region() const -> string { return information.region; }
+  auto manifest() const -> string { return information.manifest; }
+  auto name() const -> string { return information.name; }
+  auto region() const -> string { return information.region; }
 
   //cartridge.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/sg/system/system.hpp
+++ b/higan/sg/system/system.hpp
@@ -14,9 +14,9 @@ struct System {
   enum class Model : uint { SG1000, SC3000 };
   enum class Region : uint { NTSC, PAL };
 
-  inline auto model() const -> Model { return information.model; }
-  inline auto region() const -> Region { return information.region; }
-  inline auto colorburst() const -> double { return information.colorburst; }
+  auto model() const -> Model { return information.model; }
+  auto region() const -> Region { return information.region; }
+  auto colorburst() const -> double { return information.colorburst; }
 
   //system.cpp
   auto run() -> void;

--- a/higan/ws/cartridge/cartridge.hpp
+++ b/higan/ws/cartridge/cartridge.hpp
@@ -2,9 +2,9 @@ struct Cartridge : Thread, IO {
   Node::Port port;
   Node::Peripheral node;
 
-  inline auto manifest() const { return information.manifest; }
-  inline auto name() const { return information.name; }
-  inline auto orientation() const { return information.orientation; }
+  auto manifest() const { return information.manifest; }
+  auto name() const { return information.name; }
+  auto orientation() const { return information.orientation; }
 
   //cartridge.cpp
   auto main() -> void;

--- a/higan/ws/ppu/ppu.hpp
+++ b/higan/ws/ppu/ppu.hpp
@@ -25,11 +25,11 @@ struct PPU : Thread, IO {
     Node::Sprite volumeB3;
   } icon;
 
-  inline auto planar() const -> bool { return system.mode().bit(0) == 0; }
-  inline auto packed() const -> bool { return system.mode().bit(0) == 1; }
-  inline auto depth() const -> uint { return system.mode().bit(1,2) != 3 ? 2 : 4; }
-  inline auto grayscale() const -> bool { return system.mode().bit(1,2) == 0; }
-  inline auto tilemask() const -> uint { return 1023 >> !system.mode().bit(2); }
+  auto planar() const -> bool { return system.mode().bit(0) == 0; }
+  auto packed() const -> bool { return system.mode().bit(0) == 1; }
+  auto depth() const -> uint { return system.mode().bit(1,2) != 3 ? 2 : 4; }
+  auto grayscale() const -> bool { return system.mode().bit(1,2) == 0; }
+  auto tilemask() const -> uint { return 1023 >> !system.mode().bit(2); }
 
   //ppu.cpp
   auto load(Node::Object, Node::Object) -> void;

--- a/higan/ws/system/system.hpp
+++ b/higan/ws/system/system.hpp
@@ -55,11 +55,11 @@ struct System : IO {
     bool rightLatch = 0;
   } controls;
 
-  inline auto abstract() const -> bool { return information.abstract; }
-  inline auto model() const -> Model { return information.model; }
-  inline auto soc() const -> SoC { return information.soc; }
-  inline auto mode() const -> uint3 { return io.mode; }
-  inline auto memory() const -> uint { return io.mode.bit(2) == 0 ? 16_KiB : 64_KiB; }
+  auto abstract() const -> bool { return information.abstract; }
+  auto model() const -> Model { return information.model; }
+  auto soc() const -> SoC { return information.soc; }
+  auto mode() const -> uint3 { return io.mode; }
+  auto memory() const -> uint { return io.mode.bit(2) == 0 ? 16_KiB : 64_KiB; }
 
   //mode:
   //xx0 => planar tiledata


### PR DESCRIPTION
Removes all uses of inline inside the higan folder for member functions defined in structs/classes. These are considered implicitly inline by the compiler.
Does not touch methods that are declared virtual inline, inline override or inline static.