### PR TITLE
Fix for qt5 'about dialog' locking up the gui

### DIFF
--- a/hiro/qt/window.cpp
+++ b/hiro/qt/window.cpp
@@ -205,7 +205,11 @@ auto pWindow::setModal(bool modal) -> void {
       }
       Application::processEvents();
     }
+  } else {
+    bool wasVisible = qtWindow->isVisible();
+    setVisible(false);
     qtWindow->setWindowModality(Qt::NonModal);
+    setVisible(wasVisible);
   }
 }
 


### PR DESCRIPTION
Apparently the intention is to support switching the modality of a window at any time in hiro. This is probably overkill and in QT requires hiding and showing the window before the modality change takes effect. This fix allows the window to switch to non modal mode correctly.