### PR TITLE
Fix missing virtual destructors

### DIFF
--- a/higan/pce/cartridge/board/board.hpp
+++ b/higan/pce/cartridge/board/board.hpp
@@ -1,6 +1,7 @@
 namespace Board {
 
 struct Interface {
+  virtual ~Interface() = default;
   virtual auto load(Markup::Node) -> void {}
   virtual auto save(Markup::Node) -> void {}
   virtual auto read(uint8 bank, uint13 address) -> uint8 { return 0x00; }

--- a/higan/target-byuu/emulator/emulator.hpp
+++ b/higan/target-byuu/emulator/emulator.hpp
@@ -2,6 +2,7 @@ struct Emulator {
   struct Firmware;
 
   static auto construct() -> void;
+  virtual ~Emulator() = default;
   auto locate(const string& location, const string& suffix, const string& path = "") -> string;
   auto manifest() -> shared_pointer<vfs::file>;
   auto load(const string& location, const vector<uint8_t>& image) -> bool;

--- a/nall/hid.hpp
+++ b/nall/hid.hpp
@@ -41,6 +41,7 @@ private:
 
 struct Device : vector<Group> {
   Device(const string& name) : _name(name) {}
+  virtual ~Device() = default;
 
   //id => {pathID}-{vendorID}-{productID}
   auto pathID()    const -> uint32_t { return (uint32_t)(_id >> 32); }  //32-63


### PR DESCRIPTION
A few classes with virtual methods were missing virtual destructors. Found with -Wdelete-non-virtual-dtor.