### PR TITLE
Fix segfault on exit in byuu and icarus with qt5

### DIFF
--- a/higan/target-byuu/byuu.cpp
+++ b/higan/target-byuu/byuu.cpp
@@ -46,4 +46,5 @@ auto nall::main(Arguments arguments) -> void {
 
   Instances::presentation.destruct();
   Instances::settingsWindow.destruct();
+  Instances::toolsWindow.destruct();
 }

--- a/icarus/icarus.cpp
+++ b/icarus/icarus.cpp
@@ -111,6 +111,8 @@ auto main(Arguments arguments) -> void {
 
   directory::create({Path::userSettings(), "icarus/"});
   file::write({Path::userSettings(), "icarus/settings.bml"}, settings.serialize());
+
+  Instances::programWindow.destruct();
 }
 
 }


### PR DESCRIPTION
Here we need to destroy instances of gui objects explicitly when exiting the main function.