### PR TITLE
Fix pulseaudio segfault with dynamic rate setting

### DIFF
--- a/ruby/audio/pulseaudio.cpp
+++ b/ruby/audio/pulseaudio.cpp
@@ -6,6 +6,7 @@ struct AudioPulseAudio : AudioDriver {
   ~AudioPulseAudio() { terminate(); }
 
   auto create() -> bool override {
+    super.setChannels(2);
     super.setFrequency(48000);
     super.setLatency(40);
     return initialize();


### PR DESCRIPTION
The elements of vector Audio::resamplers are accessed in method Audio::output if AudioDriver::dynamic is true. At that point however it is possible that the vector has zero elements because only a call to Audio::setChannels will fill the vector.