### PR TITLE
Include pre-made config files with nightly builds.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,6 +21,7 @@ linux-x86_64-binaries_task:
         - cp -a icarus/Database higan-nightly
         - cp -a icarus/Firmware higan-nightly
         - cp -a GPLv3.txt higan-nightly
+        - cp -a extras/higan/* higan-nightly
         - zip -r higan-nightly.zip higan-nightly
 
       matrix:
@@ -42,6 +43,7 @@ linux-x86_64-binaries_task:
         - mkdir byuu-nightly/Firmware
         - cp -a higan/out/byuu byuu-nightly/byuu
         - cp -a GPLv3.txt byuu-nightly
+        - cp -a extras/byuu/* byuu-nightly
         - zip -r byuu-nightly.zip byuu-nightly
 
       byuu-nightly_artifacts:
@@ -70,6 +72,7 @@ freebsd-x86_64-binaries_task:
         - cp -a icarus/Database higan-nightly
         - cp -a icarus/Firmware higan-nightly
         - cp -a GPLv3.txt higan-nightly
+        - cp -a extras/higan/* higan-nightly
         - zip -r higan-nightly.zip higan-nightly
 
       matrix:
@@ -91,6 +94,7 @@ freebsd-x86_64-binaries_task:
         - mkdir byuu-nightly/Firmware
         - cp -a higan/out/byuu byuu-nightly/byuu
         - cp -a GPLv3.txt byuu-nightly
+        - cp -a extras/byuu/* byuu-nightly
         - zip -r byuu-nightly.zip byuu-nightly
 
       byuu-nightly_artifacts:
@@ -117,8 +121,7 @@ windows-x86_64-binaries_task:
         - cp -a icarus/Database higan-nightly
         - cp -a icarus/Firmware higan-nightly
         - cp -a GPLv3.txt higan-nightly
-        - echo "templates: ./Templates/" >> higan-nightly/paths.bml
-        - echo "data: ./Systems/" >> higan-nightly/paths.bml
+        - cp -a extras/higan/* higan-nightly
         - zip -r higan-nightly.zip higan-nightly
 
       matrix:
@@ -140,6 +143,7 @@ windows-x86_64-binaries_task:
         - mkdir byuu-nightly/Firmware
         - cp -a higan/out/byuu byuu-nightly/byuu.exe
         - cp -a GPLv3.txt byuu-nightly
+        - cp -a extras/byuu/* byuu-nightly
         - zip -r byuu-nightly.zip byuu-nightly
 
       byuu-nightly_artifacts:
@@ -162,6 +166,7 @@ macOS-x86_64-binaries_task:
         - cp -a icarus/Database higan-nightly
         - cp -a icarus/Firmware higan-nightly
         - cp -a GPLv3.txt higan-nightly
+        - cp -a extras/higan/* higan-nightly
         - zip -r higan-nightly.zip higan-nightly
 
       matrix:
@@ -183,6 +188,7 @@ macOS-x86_64-binaries_task:
         - mkdir byuu-nightly/Firmware
         - cp -a higan/out/byuu.app byuu-nightly
         - cp -a GPLv3.txt byuu-nightly
+        - cp -a extras/byuu/* byuu-nightly
         - zip -r byuu-nightly.zip byuu-nightly
 
       byuu-nightly_artifacts:

--- a/extras/README.md
+++ b/extras/README.md
@@ -1,0 +1,1 @@
+Extra files included in official release builds.

--- a/extras/byuu/settings.bml
+++ b/extras/byuu/settings.bml
@@ -1,0 +1,147 @@
+Video
+  Monitor: Primary
+  Format: ARGB24
+  Exclusive: false
+  Blocking: false
+  Flush: false
+  Shader: Blur
+  Multiplier: 2
+  Output: Scale
+  AspectCorrection: true
+  AdaptiveSizing: true
+  AutoCentering: false
+  Luminance: 1.0
+  Saturation: 1.0
+  Gamma: 1.0
+  ColorBleed: true
+  ColorEmulation: true
+  InterframeBlending: true
+  Overscan: false
+Audio
+  Exclusive: false
+  Blocking: true
+  Dynamic: false
+  Mute: false
+  Volume: 1.0
+  Balance: 0.0
+Input
+  Defocus: Block
+General
+  ShowStatusBar: true
+  Rewind: true
+  RunAhead: false
+  AutoSaveMemory: true
+  NativeFileDialogs: true
+Rewind
+  Length: 100
+  Frequency: 10
+Paths
+  Saves
+  Patches
+  Traces
+  Firmware
+Recent
+  Game-1
+  Game-2
+  Game-3
+  Game-4
+  Game-5
+  Game-6
+  Game-7
+  Game-8
+  Game-9
+VirtualPad
+  Up: Keyboard/1/Button/Up
+  Down: Keyboard/1/Button/Down
+  Left: Keyboard/1/Button/Left
+  Right: Keyboard/1/Button/Right
+  Select: Keyboard/1/Button/Apostrophe
+  Start: Keyboard/1/Button/Return
+  A: Keyboard/1/Button/Z
+  B: Keyboard/1/Button/X
+  X: Keyboard/1/Button/A
+  Y: Keyboard/1/Button/S
+  L: Keyboard/1/Button/D
+  R: Keyboard/1/Button/C
+Hotkey
+  ToggleFullscreen: Keyboard/1/Button/F11
+  FastForward: Keyboard/1/Button/Tilde
+  Rewind: Keyboard/1/Button/Backspace
+  SaveState: Keyboard/1/Button/F5
+  LoadState: Keyboard/1/Button/F7
+  DecrementStateSlot: Keyboard/1/Button/F6
+  IncrementStateSlot: Keyboard/1/Button/F8
+  PauseEmulation: Keyboard/1/Button/P
+  QuitEmulator
+Famicom
+  Visible: true
+  Path
+FamicomDiskSystem
+  Visible: true
+  Path
+  Firmware
+    BIOS.Japan
+SuperFamicom
+  Visible: true
+  Path
+SG-1000
+  Visible: true
+  Path
+MasterSystem
+  Visible: true
+  Path
+MegaDrive
+  Visible: true
+  Path
+MegaCD
+  Visible: true
+  Path
+  Firmware
+    BIOS.US
+    BIOS.Japan
+    BIOS.Europe
+PCEngine
+  Visible: true
+  Path
+SuperGrafx
+  Visible: true
+  Path
+MSX
+  Visible: true
+  Path
+MSX2
+  Visible: true
+  Path
+GameBoy
+  Visible: true
+  Path
+GameBoyColor
+  Visible: true
+  Path
+GameBoyAdvance
+  Visible: true
+  Path
+  Firmware
+    BIOS.World
+GameGear
+  Visible: true
+  Path
+WonderSwan
+  Visible: true
+  Path
+WonderSwanColor
+  Visible: true
+  Path
+PocketChallengeV2
+  Visible: true
+  Path
+NeoGeoPocket
+  Visible: true
+  Path
+  Firmware
+    BIOS.World
+NeoGeoPocketColor
+  Visible: true
+  Path
+  Firmware
+    BIOS.World

--- a/extras/higan/paths.bml
+++ b/extras/higan/paths.bml
@@ -1,0 +1,2 @@
+templates: ./Templates/
+data: ./Systems/


### PR DESCRIPTION
byuu's config file is the one shipped with the official v4 binary for Windows, with the Windows-specific driver choices removed so the binary will use the platform defaults.

higan's config file should make it use the Templates directory shipped alongside it, instead of requiring it to be moved to a platform-specific location. It was originally Windows-only, but I'm not sure why since it's definitely useful on Linux too. Not sure if it works on macOS, but we can figure that out later.

Part of #2.