### PR TITLE
Add .setChannels(2) to the PulseAudio-simple driver.

### DIFF
--- a/ruby/audio/pulseaudio-simple.cpp
+++ b/ruby/audio/pulseaudio-simple.cpp
@@ -8,6 +8,7 @@ struct AudioPulseAudioSimple : AudioDriver {
 
   auto create() -> bool override {
     super.setBlocking(true);
+    super.setChannels(2);
     super.setFrequency(48000);
     return initialize();
   }


### PR DESCRIPTION
Currently every other audio driver calls this method at initialization time, so for consistency alone we should call in here too.