### PR TITLE
In X11, don't require a running window manager.

### DIFF
--- a/hiro/gtk/desktop.cpp
+++ b/hiro/gtk/desktop.cpp
@@ -25,13 +25,14 @@ auto pDesktop::workspace() -> Geometry {
   unsigned long items, after;
   XlibAtom returnAtom;
 
-  XlibAtom netWorkarea = XInternAtom(display, "_NET_WORKAREA", XlibTrue);
+  XlibAtom netWorkarea = XInternAtom(display, "_NET_WORKAREA", XlibFalse);
+  XlibAtom cardinal = XInternAtom(display, "CARDINAL", XlibFalse);
+
   int result = XGetWindowProperty(
     display, RootWindow(display, screen), netWorkarea, 0, 4, XlibFalse,
-    XInternAtom(display, "CARDINAL", XlibTrue), &returnAtom, &format, &items, &after, &data
+    cardinal, &returnAtom, &format, &items, &after, &data
   );
 
-  XlibAtom cardinal = XInternAtom(display, "CARDINAL", XlibTrue);
   if(result == Success && returnAtom == cardinal && format == 32 && items == 4) {
     unsigned long* workarea = (unsigned long*)data;
     XCloseDisplay(display);

--- a/hiro/gtk/window.cpp
+++ b/hiro/gtk/window.cpp
@@ -655,7 +655,7 @@ auto pWindow::_synchronizeState() -> void {
   auto display = XOpenDisplay(nullptr);
   int screen = DefaultScreen(display);
   auto window = GDK_WINDOW_XID(gtk_widget_get_window(widget));
-  XlibAtom wmState = XInternAtom(display, "_NET_WM_STATE", XlibTrue);
+  XlibAtom wmState = XInternAtom(display, "_NET_WM_STATE", XlibFalse);
   XlibAtom atom;
   int format;
   unsigned long items, after;

--- a/hiro/qt/desktop.cpp
+++ b/hiro/qt/desktop.cpp
@@ -33,13 +33,13 @@ auto pDesktop::workspace() -> Geometry {
   unsigned long items, after;
   XlibAtom returnAtom;
 
-  XlibAtom netWorkarea = XInternAtom(display, "_NET_WORKAREA", XlibTrue);
+  XlibAtom netWorkarea = XInternAtom(display, "_NET_WORKAREA", XlibFalse);
+  XlibAtom cardinal = XInternAtom(display, "CARDINAL", XlibFalse);
   int result = XGetWindowProperty(
     display, RootWindow(display, screen), netWorkarea, 0, 4, XlibFalse,
-    XInternAtom(display, "CARDINAL", XlibTrue), &returnAtom, &format, &items, &after, &data
+    cardinal, &returnAtom, &format, &items, &after, &data
   );
 
-  XlibAtom cardinal = XInternAtom(display, "CARDINAL", XlibTrue);
   if(result == Success && returnAtom == cardinal && format == 32 && items == 4) {
     unsigned long* workarea = (unsigned long*)data;
     XCloseDisplay(display);

--- a/nall/xorg/clipboard.hpp
+++ b/nall/xorg/clipboard.hpp
@@ -6,9 +6,8 @@ namespace nall::Clipboard {
 
 inline auto clear() -> void {
   XDisplay display;
-  if(auto atom = XInternAtom(display, "CLIPBOARD", XlibTrue)) {
-    XSetSelectionOwner(display, atom, XlibNone, XlibCurrentTime);
-  }
+  XlibAtom atom = XInternAtom(display, "CLIPBOARD", XlibFalse);
+  XSetSelectionOwner(display, atom, XlibNone, XlibCurrentTime);
 }
 
 }

--- a/ruby/video/video.cpp
+++ b/ruby/video/video.cpp
@@ -383,9 +383,10 @@ auto Video::hasMonitors() -> vector<Monitor> {
     unsigned long size;
     unsigned long bytesAfter;
     unsigned char* data = nullptr;
+    Atom edid = XInternAtom(display, "EDID", False);
     auto property = XRRGetOutputProperty(
       display, resources->outputs[index],
-      XInternAtom(display, "EDID", 1), 0, 384,
+      edid, 0, 384,
       0, 0, 0, &actualType, &actualFormat, &size, &bytesAfter, &data
     );
     if(size >= 128) {

--- a/ruby/video/xvideo.cpp
+++ b/ruby/video/xvideo.cpp
@@ -44,8 +44,8 @@ struct VideoXVideo : VideoDriver {
   auto setBlocking(bool blocking) -> bool override {
     bool result = false;
     Display* display = XOpenDisplay(nullptr);
-    Atom atom = XInternAtom(display, "XV_SYNC_TO_VBLANK", true);
-    if(atom != None && _port >= 0) {
+    Atom atom = XInternAtom(display, "XV_SYNC_TO_VBLANK", false);
+    if(_port >= 0) {
       XvSetPortAttribute(display, _port, atom, self.blocking);
       result = true;
     }
@@ -229,8 +229,8 @@ private:
     for(auto n : range(attributeCount)) {
       if(string{attributeList[n].name} == "XV_AUTOPAINT_COLORKEY") {
         //set colorkey to auto paint, so that Xv video output is always visible
-        Atom atom = XInternAtom(_display, "XV_AUTOPAINT_COLORKEY", true);
-        if(atom != None) XvSetPortAttribute(_display, _port, atom, 1);
+        Atom atom = XInternAtom(_display, "XV_AUTOPAINT_COLORKEY", false);
+        XvSetPortAttribute(_display, _port, atom, 1);
       }
     }
     XFree(attributeList);


### PR DESCRIPTION
Previously, hiro and ruby set `only_if_exists=True` when querying the X server for atoms. Thus, when running with a window-manager that has already set up `_NET_WORKAREA` and `EDID` atoms, higan retrieved them and used them to query for properties. When running *outside* a window-manager, higan would not create those atoms, and thus wound up sending invalid queries and crashing.

Now, we always set `only_if_exists=False`, and thus always create the atoms we want to use. It's just one less failure mode to worry about.

Fixes #11.