### PR TITLE
Fix logic error in sync.hpp

### DIFF
--- a/nall/cd/sync.hpp
+++ b/nall/cd/sync.hpp
@@ -18,7 +18,7 @@ inline auto verify(array_view<uint8_t> sector) -> bool {
   if(sector.size() != 12 && sector.size() != 2352) return false;
 
   for(uint n : range(12)) {
-    if(sector[n] != (n == 0 || n == 11) ? 0x00 : 0xff) return false;
+    if(sector[n] != ((n == 0 || n == 11) ? 0x00 : 0xff)) return false;
   }
 
   return true;


### PR DESCRIPTION
Found by enabling more warnings
../nall/cd/sync.hpp: In function 'bool nall::CD::Sync::verify(nall::array_view<unsigned char>)':
../nall/cd/sync.hpp:21:41: warning: ?: using integer constants in boolean context [-Wint-in-bool-context]
   21 |     if(sector[n] != (n == 0 || n == 11) ? 0x00 : 0xff) return false;
