### PR TITLE
target-byuu: Fix crash in Sound Novel Tsukuru or Derby Stallion 96 when using the simple UI (issue #47)

### DIFF
--- a/higan/sfc/slot/bsmemory/serialization.cpp
+++ b/higan/sfc/slot/bsmemory/serialization.cpp
@@ -1,6 +1,6 @@
 auto BSMemory::serialize(serializer& s) -> void {
-  Thread::serialize(s);
   if(ROM) return;
+  Thread::serialize(s);
 
   s.array(memory.data(), memory.size());
 


### PR DESCRIPTION
The simplified UI (byuu/lucia) is crashing on games with a BS-X-Slot.

The memory-cards are apparently recognized as rom and not flash (that's not necessarily correct), so the flash chip interface is not emulated and _handle is null in higan/emulator/scheduler/thread.cpp. 

It's crashing during the first save-state while rewind is running. Since Rewind is not a feature of higan/luna, it's not crashing there. 

