### PR TITLE
nall: Quiet a compiler warning about re-defining a macro.

### DIFF
--- a/nall/recompiler/amd64/encoder-instructions.hpp
+++ b/nall/recompiler/amd64/encoder-instructions.hpp
@@ -99,6 +99,7 @@
   auto sub (reg64 rt, reg64 rs) { op(0x29); }
   auto test(reg64 rt, reg64 rs) { op(0x85); }
   auto xor (reg64 rt, reg64 rs) { op(0x31); }
+  #undef op
 
   #define op(code, reg) \
     auto _rt = (uint)rt; \


### PR DESCRIPTION
Every other block `#undef`ines "op" afterward, this one should too.