### PR TITLE
fix SNES OAM address reset

### DIFF
--- a/higan/sfc/ppu-performance/io.cpp
+++ b/higan/sfc/ppu-performance/io.cpp
@@ -185,7 +185,7 @@ auto PPU::writeIO(uint24 address, uint8 data) -> void {
 
   //INIDISP
   case 0x2100: {
-    if(io.displayDisable && vcounter() == vdisp()) obj.addressReset();
+    if(io.displayDisable && cpu.vcounter() == vdisp()) obj.addressReset();
     io.displayBrightness = data.bit(0,3);
     io.displayDisable    = data.bit(7);
     return;


### PR DESCRIPTION
This fixes a graphical bug when booting Mahjong Taikai II for the SNES in the ppu-performance renderer.

The fix is copied from bsnes-emu. It checks the CPU vcounter rather than the PPU vcounter. The PPU vcounter only updates once per scanline in the performance renderer, so it is behind one scanline at this point.