### PR TITLE
icarus: Fix crash generating manifests for CDs.

### DIFF
--- a/icarus/compact-disc/compact-disc.cpp
+++ b/icarus/compact-disc/compact-disc.cpp
@@ -45,7 +45,7 @@ auto CompactDisc::readDataSectorBCD(string pathname, uint sectorID) -> vector<ui
       if(!track.isData()) continue;
       if(auto index = track.index(1)) {
         vector<uint8_t> sector;
-        sector.resize(2048);
+        sector.resize(2448);
         fp.seek(2448 * (abs(session.leadIn.lba) + index->lba + sectorID) + 16);
         fp.read({sector.data(), 2448});
         return sector;


### PR DESCRIPTION
After importing a BIN/CUE image, icarus stores it in a format which includes 2048 data bytes, 304 error correction bytes, and 96 subchannel data bytes per sector, for a total of 2448 bytes. Previously, icarus would allocate a 2048 byte buffer and try to read 2448 bytes of data into it, causing a buffer overflow and (sometimes) a crash. Now, we make sure tha buffer is correctly-sized before we fill it in.

Fixes #73.