### PR TITLE
Revert "Update instructions.cpp"

### DIFF
--- a/higan/component/processor/sm83/instructions.cpp
+++ b/higan/component/processor/sm83/instructions.cpp
@@ -268,9 +268,7 @@ auto SM83::instructionOR_Direct_Indirect(uint8& target, uint16& source) -> void 
 }
 
 auto SM83::instructionPOP_Direct(uint16& data) -> void {
-  //mask off the lower four bits, not sure if this should be for only 0xF1 POP AF
-  //or in general but the folks tell me it's okay so... --K
-  data = pop() & ~15;
+  data = pop();
 }
 
 auto SM83::instructionPOP_Direct_AF(uint16& data) -> void {


### PR DESCRIPTION
This reverts commit 31c635401714186284ddbfa3294213c85cb7c614.

Kawa made this fix to higan as suggested in issue #55, leaving a comment wondering whether the fix should just be for the 0xF1 "POP AF" instruction or all POP instructions. A couple of days later on the ares branch, byuu committed a different fix as part of 982a90a (ares v114), one that *did* distinguish between POP AF and other POP instructions.

Now we have the proper fix from the ares branch, we can revert the buggy fix.

Fixes #78.