### PR TITLE
gb: fix cgb hdma abort bug

### DIFF
--- a/higan/gb/cpu/io.cpp
+++ b/higan/gb/cpu/io.cpp
@@ -240,11 +240,12 @@ auto CPU::writeIO(uint cycle, uint16 address, uint8 data) -> void {
 
   if(Model::GameBoyColor())
   if(address == 0xff55 && cycle == 2) {  //HDMA5
+    const auto dmaWasCompleted = status.dmaCompleted;
     status.dmaLength    = (data.bit(0,6) + 1) * 16;
     status.dmaMode      = data.bit(7);
     status.dmaCompleted = !status.dmaMode;
 
-    if(status.dmaMode == 0) {
+    if(dmaWasCompleted && status.dmaMode == 0) {
       do {
         for(uint loop : range(16)) {
           writeDMA(status.dmaTarget++, readDMA(status.dmaSource++, 0xff));

--- a/higan/gb/cpu/timing.cpp
+++ b/higan/gb/cpu/timing.cpp
@@ -83,11 +83,13 @@ auto CPU::hblank() -> void {
 }
 
 auto CPU::hblankTrigger() -> void {
-  if(status.dmaMode == 1 && status.dmaLength && ppu.status.ly < 144) {
+  if(status.dmaMode == 1 && !status.dmaCompleted && status.dmaLength && ppu.status.ly < 144) {
     for(uint n : range(16)) {
       writeDMA(status.dmaTarget++, readDMA(status.dmaSource++, 0xff));
       status.dmaLength--;
       if(n & 1) step(1 << status.speedDouble);
     }
+  if (0 == status.dmaLength)
+    status.dmaCompleted = 1;
   }
 }


### PR DESCRIPTION
Tauwasser provided this patch in the old forums, but it was never applied to higan until now.

The easiest way to reproduce this issue is to start a new game of Pokémon Crystal, walk up to the town map in your bedroom and look at it. When the message "It's the TOWN MAP." appears, if all the blanks space outside the room graphics suddenly displays a double-quote tile, that's the wrong behaviour.

Fixes https://github.com/ares-emu/ares/pull/10