### PR TITLE
hiro/cocoa: Fix Frame setVisible/setGeometry

### DIFF
--- a/hiro/cocoa/widget/frame.cpp
+++ b/hiro/cocoa/widget/frame.cpp
@@ -39,14 +39,14 @@ auto pFrame::remove(sSizable sizable) -> void {
 
 auto pFrame::setEnabled(bool enabled) -> void {
   pWidget::setEnabled(enabled);
-  if(auto sizable = _sizable()) sizable->setEnabled(sizable->self().enabled(true));
+  if(auto& sizable = state().sizable) sizable->setEnabled(enabled);
 }
 
 auto pFrame::setFont(const Font& font) -> void {
   @autoreleasepool {
     [cocoaView setTitleFont:pFont::create(font)];
   }
-  if(auto sizable = _sizable()) sizable->setFont(sizable->self().font(true));
+  if(auto& sizable = state().sizable) sizable->setFont(font);
 }
 
 auto pFrame::setGeometry(Geometry geometry) -> void {
@@ -56,7 +56,7 @@ auto pFrame::setGeometry(Geometry geometry) -> void {
     geometry.x() - 3, geometry.y() - (empty ? size.height() - 2 : 1),
     geometry.width() + 6, geometry.height() + (empty ? size.height() + 2 : 5)
   });
-  if(auto sizable = _sizable()) {
+  if(auto& sizable = state().sizable) {
     sizable->setGeometry({
       geometry.x() + 1, geometry.y() + (empty ? 1 : size.height() - 2),
       geometry.width() - 2, geometry.height() - (empty ? 1 : size.height() - 1)
@@ -72,14 +72,7 @@ auto pFrame::setText(const string& text) -> void {
 
 auto pFrame::setVisible(bool visible) -> void {
   pWidget::setVisible(visible);
-  if(auto sizable = _sizable()) sizable->setVisible(sizable->self().visible(true));
-}
-
-auto pFrame::_sizable() -> maybe<pSizable&> {
-  if(auto sizable = state().sizable) {
-    if(auto self = sizable->self()) return *self;
-  }
-  return {};
+  if(auto& sizable = state().sizable) sizable->setVisible(visible);
 }
 
 }

--- a/hiro/cocoa/widget/frame.hpp
+++ b/hiro/cocoa/widget/frame.hpp
@@ -20,8 +20,6 @@ struct pFrame : pWidget {
   auto setText(const string& text) -> void;
   auto setVisible(bool visible) -> void override;
 
-  auto _sizable() -> maybe<pSizable&>;
-
   CocoaFrame* cocoaFrame = nullptr;
 };
 


### PR DESCRIPTION
The way this widget retrieved its child sizable was faulty. In practice this meant that the various setX methods wouldn't propagate and while the Frame itself was visible, its contents usually weren't.

Luckily this widget is used sparingly, but most notably higan's audio/video/input settings panels were affected.

Before:
<img width="752" alt="Screenshot 2020-08-22 at 21 48 11" src="https://user-images.githubusercontent.com/3380580/90964504-79b5cc80-e4c1-11ea-8c93-dc495e4af468.png">
After:
<img width="752" alt="Screenshot 2020-08-22 at 21 47 15" src="https://user-images.githubusercontent.com/3380580/90964502-76224580-e4c1-11ea-838d-8c097081789a.png">