### PR TITLE
sfc: Clear shift registers at start of auto joypad polling.

### DIFF
--- a/higan/sfc/cpu/timing.cpp
+++ b/higan/sfc/cpu/timing.cpp
@@ -150,11 +150,11 @@ alwaysinline auto CPU::joypadEdge() -> void {
         controllerPort1.latch(0);
         controllerPort2.latch(0);
 
-        //shift registers are flushed at start of auto joypad polling
-        io.joy1 = ~0;
-        io.joy2 = ~0;
-        io.joy3 = ~0;
-        io.joy4 = ~0;
+        //shift registers are cleared at start of auto joypad polling
+        io.joy1 = 0;
+        io.joy2 = 0;
+        io.joy3 = 0;
+        io.joy4 = 0;
       }
 
       uint2 port0 = controllerPort1.data();


### PR DESCRIPTION
This behaviour was introduced in v104r02 (1135716) to fix Nuke (PD), but it turns out there are a number of titles that depend on the initial state of the shift registers.

When the initial state is zero:

  - Taikyoku Igo - Goliath: Pressing start or A takes you to the title screen, but pressing start or A at the title screen does nothing

When the initial state is non-zero:

  - Nuke (PD): inputs do not work
  - Tatakae Genshijin 2: attract sequence ends early
  - Williams Arcade's Greatest Hits: inputs fire on their own
  - World Masters Golf: inputs do not work at all
  - Pro Football: Dropdown intro is interrupted and title screen is skipped
  - Taikyoku Igo - Goliath: Pressing start or A takes you to the title screen, then immediately dismisses it

In v107r02 (2c84a4e) byuu changed the behaviour to set the initial state to all-1s instead of all-0s, to get Taikyoku Igo - Goliath working. However, hardware testing by Jonas Quinn verified that all-0s is actually what happens. The problem with Taikyoku Igo - Goliath must be something else.