### PR TITLE
SFC: Fix auto-joypad-read in Taikyoku Igo - Goliath

### DIFF
--- a/higan/sfc/cpu/io.cpp
+++ b/higan/sfc/cpu/io.cpp
@@ -126,6 +126,7 @@ auto CPU::writeCPU(uint24 address, uint8 data) -> void {
 
   case 0x4200:  //NMITIMEN
     io.autoJoypadPoll = data.bit(0);
+    if(!io.autoJoypadPoll) status.autoJoypadLatch = 0;
     nmitimenUpdate(data);
     return;
 


### PR DESCRIPTION
You cannot start a new game because input is not working on the title screen.
It's reading the auto joypad shift registers too early
(around v=225, h=49 dots), resulting in no input, since higan already
cleared the shift-registers of the previous frame.

Auto-joypad-read should start on v=225 between h=32.5 and h=95.5
according to Anomie's timing doc. Hardware-testing has shown that the
range should be h=32.5 to h=96 or you'd miss it on a few frames.
In the current code auto-joypad-read can start anywhere on the scanline.

Ys 5 had a similar problem back in bsnes v085 and is still working.
It turned auto-joypad-read on late in vblank and that was breaking input.

Also emulated that Auto-Joypad-Read is disabled while it is running,
when you disable it for the rest of the frame in the 4200 register