### PR TITLE
Fix debug logging for Linux systems

### DIFF
--- a/higan-ui/emulator/platform.cpp
+++ b/higan-ui/emulator/platform.cpp
@@ -78,9 +78,9 @@ auto Emulator::event(higan::Event event) -> void {
 
 auto Emulator::log(string_view message) -> void {
   if(!system.log) {
-    directory::create({"/tmpfs/Logs/", system.name, "/"});
+    directory::create({"/tmp/Logs/", system.name, "/"});
     string datetime = chrono::local::datetime().transform("-: ", "  _").replace(" ", "");
-    system.log.open({"/tmpfs/Logs/", system.name, "/event-", datetime, ".log"}, file::mode::write);
+    system.log.open({"/tmp/Logs/", system.name, "/event-", datetime, ".log"}, file::mode::write);
   }
   system.log.print(message);
 }


### PR DESCRIPTION
`/tmpfs/` doesn't exist on Linux, and the root directory of a system can only be modified by root, but `/tmp/` can be modified by anyone usually, so I changed this to Linux's standards, since more people use Linux than FreeBSD, but I can create a more nuanced solution to support both if you want.