### PR TITLE
Fix palettes and save games in Pokemon Crystal (issue #85)

### DIFF
--- a/higan/gb/ppu/io.cpp
+++ b/higan/gb/ppu/io.cpp
@@ -69,9 +69,9 @@ auto PPU::readIO(uint cycle, uint16 address, uint8 data) -> uint8 {
 
   if(address == 0xff48 && cycle == 2) {  //OBP0
     data.bit(0,1) = obp[0][0];
-    data.bit(2,3) = obp[1][1];
-    data.bit(4,5) = obp[2][2];
-    data.bit(6,7) = obp[3][3];
+    data.bit(2,3) = obp[0][1];
+    data.bit(4,5) = obp[0][2];
+    data.bit(6,7) = obp[0][3];
     return data;
   }
 

--- a/icarus/cartridge/game-boy.cpp
+++ b/icarus/cartridge/game-boy.cpp
@@ -237,10 +237,12 @@ auto GameBoy::heuristics(vector<uint8_t>& data, string location) -> string {
   }
 
   switch(read(0x0149)) { default:
-  case 0x00: ramSize =  0 * 1024; break;
-  case 0x01: ramSize =  2 * 1024; break;
-  case 0x02: ramSize =  8 * 1024; break;
-  case 0x03: ramSize = 32 * 1024; break;
+  case 0x00: ramSize =   0 * 1024; break;
+  case 0x01: ramSize =   2 * 1024; break;
+  case 0x02: ramSize =   8 * 1024; break;
+  case 0x03: ramSize =  32 * 1024; break;
+  case 0x04: ramSize = 128 * 1024; break;
+  case 0x05: ramSize =  64 * 1024; break;
   }
 
   if(mapper == "MBC2" && ram) ramSize = 256;


### PR DESCRIPTION
1. OBP0 was read incorrectly, resulting in incorrect sprite colors.
2. The 'icarus' tool did not support 128KB and 64KB SRAM sizes.
3. The MBC3 mapper did not recognize >32KB SRAM, breaking save games.

There is still a bug with the realtime clock that I was unable to fix.

See https://github.com/higan-emu/higan/issues/85#issuecomment-678931345 for more details.