### PR TITLE
Update GBC ppu.hpp to fix background priority bugs

### DIFF
--- a/higan/gb/ppu/cgb.cpp
+++ b/higan/gb/ppu/cgb.cpp
@@ -107,7 +107,7 @@ auto PPU::runBackgroundCGB() -> void {
 
   bg.color = color;
   bg.palette = index;
-  bg.priority = background.attr & 0x80;
+  bg.priority = (background.attr & 0x80) >> 7;
 }
 
 auto PPU::runWindowCGB() -> void {
@@ -132,7 +132,7 @@ auto PPU::runWindowCGB() -> void {
 
   bg.color = color;
   bg.palette = index;
-  bg.priority = window.attr & 0x80;
+  bg.priority = (window.attr & 0x80) >> 7;
 }
 
 auto PPU::runObjectsCGB() -> void {


### PR DESCRIPTION
This fixes a bug setting the background priority bits in cgb.cpp. Fixes issue #96 and #97

References:
https://github.com/higan-emu/higan/blob/master/higan/gb/ppu/cgb.cpp#L110
https://github.com/higan-emu/higan/blob/master/higan/gb/ppu/cgb.cpp#L135

This type used to be "bool" in earlier higan releases but was changed to uint1.
Assigning "attr & 0x80" will set priority to true (1) when bit 7 is set.
But with the uint1 type, it ends up always setting the value to false (0)
I changed it to nall::boolean, which acts the same way and carries the "default initialize to 0" behavior of uint1.
bool would default to not being initialized and since I can't rule out side effects for that change, I went with the boolean type.