### PR TITLE
Expansion and renaming of virtual pad inputs

### DIFF
--- a/byuu/emulator/famicom.cpp
+++ b/byuu/emulator/famicom.cpp
@@ -77,7 +77,7 @@ auto Famicom::input(higan::Node::Input node) -> void {
   if(name == "Right"     ) mapping = virtualPad.right;
   if(name == "B"         ) mapping = virtualPad.a;
   if(name == "A"         ) mapping = virtualPad.b;
-  if(name == "Select"    ) mapping = virtualPad.select;
+  if(name == "Select"    ) mapping = virtualPad.back;
   if(name == "Start"     ) mapping = virtualPad.start;
   if(name == "Microphone") mapping = virtualPad.x;
 
@@ -214,7 +214,7 @@ auto FamicomDiskSystem::input(higan::Node::Input node) -> void {
   if(name == "Right"     ) mapping = virtualPad.right;
   if(name == "B"         ) mapping = virtualPad.a;
   if(name == "A"         ) mapping = virtualPad.b;
-  if(name == "Select"    ) mapping = virtualPad.select;
+  if(name == "Select"    ) mapping = virtualPad.back;
   if(name == "Start"     ) mapping = virtualPad.start;
   if(name == "Microphone") mapping = virtualPad.x;
 

--- a/byuu/emulator/game-boy-advance.cpp
+++ b/byuu/emulator/game-boy-advance.cpp
@@ -63,9 +63,9 @@ auto GameBoyAdvance::input(higan::Node::Input node) -> void {
   if(name == "Right" ) mapping = virtualPad.right;
   if(name == "B"     ) mapping = virtualPad.a;
   if(name == "A"     ) mapping = virtualPad.b;
-  if(name == "L"     ) mapping = virtualPad.l;
-  if(name == "R"     ) mapping = virtualPad.r;
-  if(name == "Select") mapping = virtualPad.select;
+  if(name == "L"     ) mapping = virtualPad.lb;
+  if(name == "R"     ) mapping = virtualPad.rb;
+  if(name == "Select") mapping = virtualPad.back;
   if(name == "Start" ) mapping = virtualPad.start;
 
   if(mapping) {

--- a/byuu/emulator/game-boy.cpp
+++ b/byuu/emulator/game-boy.cpp
@@ -62,7 +62,7 @@ auto GameBoy::input(higan::Node::Input node) -> void {
   if(name == "Right" ) mapping = virtualPad.right;
   if(name == "B"     ) mapping = virtualPad.a;
   if(name == "A"     ) mapping = virtualPad.b;
-  if(name == "Select") mapping = virtualPad.select;
+  if(name == "Select") mapping = virtualPad.back;
   if(name == "Start" ) mapping = virtualPad.start;
 
   if(mapping) {
@@ -121,7 +121,7 @@ auto GameBoyColor::input(higan::Node::Input node) -> void {
   if(name == "Right" ) mapping = virtualPad.right;
   if(name == "B"     ) mapping = virtualPad.a;
   if(name == "A"     ) mapping = virtualPad.b;
-  if(name == "Select") mapping = virtualPad.select;
+  if(name == "Select") mapping = virtualPad.back;
   if(name == "Start" ) mapping = virtualPad.start;
 
   if(mapping) {

--- a/byuu/emulator/mega-drive.cpp
+++ b/byuu/emulator/mega-drive.cpp
@@ -71,9 +71,9 @@ auto MegaDrive::input(higan::Node::Input node) -> void {
   if(name == "B"    ) mapping = virtualPad.a;
   if(name == "C"    ) mapping = virtualPad.b;
   if(name == "X"    ) mapping = virtualPad.y;
-  if(name == "Y"    ) mapping = virtualPad.l;
-  if(name == "Z"    ) mapping = virtualPad.r;
-  if(name == "Mode" ) mapping = virtualPad.select;
+  if(name == "Y"    ) mapping = virtualPad.lb;
+  if(name == "Z"    ) mapping = virtualPad.rb;
+  if(name == "Mode" ) mapping = virtualPad.back;
   if(name == "Start") mapping = virtualPad.start;
 
   if(mapping) {
@@ -188,9 +188,9 @@ auto MegaCD::input(higan::Node::Input node) -> void {
   if(name == "B"    ) mapping = virtualPad.a;
   if(name == "C"    ) mapping = virtualPad.b;
   if(name == "X"    ) mapping = virtualPad.y;
-  if(name == "Y"    ) mapping = virtualPad.l;
-  if(name == "Z"    ) mapping = virtualPad.r;
-  if(name == "Mode" ) mapping = virtualPad.select;
+  if(name == "Y"    ) mapping = virtualPad.lb;
+  if(name == "Z"    ) mapping = virtualPad.rb;
+  if(name == "Mode" ) mapping = virtualPad.back;
   if(name == "Start") mapping = virtualPad.start;
 
   if(mapping) {

--- a/byuu/emulator/nintendo-64.cpp
+++ b/byuu/emulator/nintendo-64.cpp
@@ -63,21 +63,21 @@ auto Nintendo64::open(higan::Node::Object node, string name, vfs::file::mode mod
 auto Nintendo64::input(higan::Node::Input node) -> void {
   auto name = node->name();
   maybe<InputMapping&> mapping;
-  if(name == "X-axis" ) mapping = virtualPad.xAxis;
-  if(name == "Y-axis" ) mapping = virtualPad.yAxis;
+  if(name == "X-axis" ) mapping = virtualPad.lStickAxisX;
+  if(name == "Y-axis" ) mapping = virtualPad.lStickAxisY;
   if(name == "Up"     ) mapping = virtualPad.up;
   if(name == "Down"   ) mapping = virtualPad.down;
   if(name == "Left"   ) mapping = virtualPad.left;
   if(name == "Right"  ) mapping = virtualPad.right;
-  if(name == "B"      ) mapping = virtualPad.a;
-  if(name == "A"      ) mapping = virtualPad.b;
-  if(name == "C-Up"   ) mapping = virtualPad.cUp;
-  if(name == "C-Down" ) mapping = virtualPad.cDown;
-  if(name == "C-Left" ) mapping = virtualPad.cLeft;
-  if(name == "C-Right") mapping = virtualPad.cRight;
-  if(name == "L"      ) mapping = virtualPad.l;
-  if(name == "R"      ) mapping = virtualPad.r;
-  if(name == "Z"      ) mapping = virtualPad.select;
+  if(name == "B"      ) mapping = virtualPad.x;
+  if(name == "A"      ) mapping = virtualPad.a;
+  if(name == "C-Up"   ) mapping = virtualPad.rStickUp;
+  if(name == "C-Down" ) mapping = virtualPad.rStickDown;
+  if(name == "C-Left" ) mapping = virtualPad.rStickLeft;
+  if(name == "C-Right") mapping = virtualPad.rStickRight;
+  if(name == "L"      ) mapping = virtualPad.lb;
+  if(name == "R"      ) mapping = virtualPad.rb;
+  if(name == "Z"      ) mapping = virtualPad.lt;
   if(name == "Start"  ) mapping = virtualPad.start;
 
   if(mapping) {
@@ -135,21 +135,21 @@ auto Nintendo64DD::open(higan::Node::Object node, string name, vfs::file::mode m
 auto Nintendo64DD::input(higan::Node::Input node) -> void {
   auto name = node->name();
   maybe<InputMapping&> mapping;
-  if(name == "X-axis" ) mapping = virtualPad.xAxis;
-  if(name == "Y-axis" ) mapping = virtualPad.yAxis;
+  if(name == "X-axis" ) mapping = virtualPad.lStickAxisX;
+  if(name == "Y-axis" ) mapping = virtualPad.lStickAxisY;
   if(name == "Up"     ) mapping = virtualPad.up;
   if(name == "Down"   ) mapping = virtualPad.down;
   if(name == "Left"   ) mapping = virtualPad.left;
   if(name == "Right"  ) mapping = virtualPad.right;
-  if(name == "B"      ) mapping = virtualPad.a;
-  if(name == "A"      ) mapping = virtualPad.b;
-  if(name == "C-Up"   ) mapping = virtualPad.cUp;
-  if(name == "C-Down" ) mapping = virtualPad.cDown;
-  if(name == "C-Left" ) mapping = virtualPad.cLeft;
-  if(name == "C-Right") mapping = virtualPad.cRight;
-  if(name == "L"      ) mapping = virtualPad.l;
-  if(name == "R"      ) mapping = virtualPad.r;
-  if(name == "Z"      ) mapping = virtualPad.select;
+  if(name == "B"      ) mapping = virtualPad.x;
+  if(name == "A"      ) mapping = virtualPad.a;
+  if(name == "C-Up"   ) mapping = virtualPad.rStickUp;
+  if(name == "C-Down" ) mapping = virtualPad.rStickDown;
+  if(name == "C-Left" ) mapping = virtualPad.rStickLeft;
+  if(name == "C-Right") mapping = virtualPad.rStickRight;
+  if(name == "L"      ) mapping = virtualPad.lb;
+  if(name == "R"      ) mapping = virtualPad.rb;
+  if(name == "Z"      ) mapping = virtualPad.lt;
   if(name == "Start"  ) mapping = virtualPad.start;
 
   if(mapping) {

--- a/byuu/emulator/pc-engine.cpp
+++ b/byuu/emulator/pc-engine.cpp
@@ -81,7 +81,7 @@ auto PCEngine::input(higan::Node::Input node) -> void {
   if(name == "Right" ) mapping = virtualPad.right;
   if(name == "II"    ) mapping = virtualPad.a;
   if(name == "I"     ) mapping = virtualPad.b;
-  if(name == "Select") mapping = virtualPad.select;
+  if(name == "Select") mapping = virtualPad.back;
   if(name == "Run"   ) mapping = virtualPad.start;
 
   if(mapping) {
@@ -192,7 +192,7 @@ auto PCEngineCD::input(higan::Node::Input node) -> void {
   if(name == "Right" ) mapping = virtualPad.right;
   if(name == "II"    ) mapping = virtualPad.a;
   if(name == "I"     ) mapping = virtualPad.b;
-  if(name == "Select") mapping = virtualPad.select;
+  if(name == "Select") mapping = virtualPad.back;
   if(name == "Run"   ) mapping = virtualPad.start;
 
   if(mapping) {
@@ -261,7 +261,7 @@ auto SuperGrafx::input(higan::Node::Input node) -> void {
   if(name == "Right" ) mapping = virtualPad.right;
   if(name == "II"    ) mapping = virtualPad.a;
   if(name == "I"     ) mapping = virtualPad.b;
-  if(name == "Select") mapping = virtualPad.select;
+  if(name == "Select") mapping = virtualPad.back;
   if(name == "Run"   ) mapping = virtualPad.start;
 
   if(mapping) {

--- a/byuu/emulator/playstation.cpp
+++ b/byuu/emulator/playstation.cpp
@@ -103,16 +103,16 @@ auto PlayStation::input(higan::Node::Input node) -> void {
   if(name == "Circle"  ) mapping = virtualPad.b;
   if(name == "Square"  ) mapping = virtualPad.x;
   if(name == "Triangle") mapping = virtualPad.y;
-  if(name == "L1"      ) mapping = virtualPad.l;
-  if(name == "L2"      );
-  if(name == "R1"      ) mapping = virtualPad.r;
-  if(name == "R2"      );
-  if(name == "Select"  ) mapping = virtualPad.select;
+  if(name == "L1"      ) mapping = virtualPad.lb;
+  if(name == "L2"      ) mapping = virtualPad.lt;
+  if(name == "R1"      ) mapping = virtualPad.rb;
+  if(name == "R2"      ) mapping = virtualPad.rt;
+  if(name == "Select"  ) mapping = virtualPad.back;
   if(name == "Start"   ) mapping = virtualPad.start;
-  if(name == "LX-axis" ) mapping = virtualPad.xAxis;
-  if(name == "LY-axis" ) mapping = virtualPad.yAxis;
-  if(name == "RX-axis" );
-  if(name == "RY-axis" );
+  if(name == "LX-axis" ) mapping = virtualPad.lStickAxisX;
+  if(name == "LY-axis" ) mapping = virtualPad.lStickAxisY;
+  if(name == "RX-axis" ) mapping = virtualPad.rStickAxisX;
+  if(name == "RY-axis" ) mapping = virtualPad.rStickAxisY;
   if(name == "L-thumb" );
   if(name == "R-thumb" );
 

--- a/byuu/emulator/super-famicom.cpp
+++ b/byuu/emulator/super-famicom.cpp
@@ -206,9 +206,9 @@ auto SuperFamicom::input(higan::Node::Input node) -> void {
   if(name == "A"     ) mapping = virtualPad.b;
   if(name == "Y"     ) mapping = virtualPad.x;
   if(name == "X"     ) mapping = virtualPad.y;
-  if(name == "L"     ) mapping = virtualPad.l;
-  if(name == "R"     ) mapping = virtualPad.r;
-  if(name == "Select") mapping = virtualPad.select;
+  if(name == "L"     ) mapping = virtualPad.lb;
+  if(name == "R"     ) mapping = virtualPad.rb;
+  if(name == "Select") mapping = virtualPad.back;
   if(name == "Start" ) mapping = virtualPad.start;
 
   if(mapping) {

--- a/byuu/emulator/wonderswan.cpp
+++ b/byuu/emulator/wonderswan.cpp
@@ -75,8 +75,8 @@ auto WonderSwan::input(higan::Node::Input node) -> void {
   maybe<InputMapping&> mapping;
   if(name == "Y1"   ) mapping = virtualPad.x;
   if(name == "Y2"   ) mapping = virtualPad.y;
-  if(name == "Y3"   ) mapping = virtualPad.l;
-  if(name == "Y4"   ) mapping = virtualPad.r;
+  if(name == "Y3"   ) mapping = virtualPad.lb;
+  if(name == "Y4"   ) mapping = virtualPad.rb;
   if(name == "X1"   ) mapping = virtualPad.up;
   if(name == "X2"   ) mapping = virtualPad.right;
   if(name == "X3"   ) mapping = virtualPad.down;
@@ -147,8 +147,8 @@ auto WonderSwanColor::input(higan::Node::Input node) -> void {
   maybe<InputMapping&> mapping;
   if(name == "Y1"   ) mapping = virtualPad.x;
   if(name == "Y2"   ) mapping = virtualPad.y;
-  if(name == "Y3"   ) mapping = virtualPad.l;
-  if(name == "Y4"   ) mapping = virtualPad.r;
+  if(name == "Y3"   ) mapping = virtualPad.lb;
+  if(name == "Y4"   ) mapping = virtualPad.rb;
   if(name == "X1"   ) mapping = virtualPad.up;
   if(name == "X2"   ) mapping = virtualPad.right;
   if(name == "X3"   ) mapping = virtualPad.down;
@@ -225,7 +225,7 @@ auto PocketChallengeV2::input(higan::Node::Input node) -> void {
   if(name == "Circle") mapping = virtualPad.b;
   if(name == "Clear" ) mapping = virtualPad.y;
   if(name == "View"  ) mapping = virtualPad.start;
-  if(name == "Escape") mapping = virtualPad.select;
+  if(name == "Escape") mapping = virtualPad.back;
 
   if(mapping) {
     auto value = mapping->value();

--- a/byuu/input/input.cpp
+++ b/byuu/input/input.cpp
@@ -216,24 +216,32 @@ auto InputAxis::value() -> int16_t {
 //
 
 VirtualPad::VirtualPad() {
-  mappings.append(&xAxis);
-  mappings.append(&yAxis);
   mappings.append(&up);
   mappings.append(&down);
   mappings.append(&left);
   mappings.append(&right);
-  mappings.append(&select);
-  mappings.append(&start);
   mappings.append(&a);
   mappings.append(&b);
   mappings.append(&x);
   mappings.append(&y);
-  mappings.append(&l);
-  mappings.append(&r);
-  mappings.append(&cUp);
-  mappings.append(&cDown);
-  mappings.append(&cLeft);
-  mappings.append(&cRight);
+  mappings.append(&back);
+  mappings.append(&start);
+  mappings.append(&lb);
+  mappings.append(&lt);
+  mappings.append(&rb);
+  mappings.append(&rt);
+  mappings.append(&lStickAxisX);
+  mappings.append(&lStickAxisY);
+  mappings.append(&lStickUp);
+  mappings.append(&lStickDown);
+  mappings.append(&lStickLeft);
+  mappings.append(&lStickRight);
+  mappings.append(&rStickAxisX);
+  mappings.append(&rStickAxisY);
+  mappings.append(&rStickUp);
+  mappings.append(&rStickDown);
+  mappings.append(&rStickLeft);
+  mappings.append(&rStickRight);
 }
 
 //

--- a/byuu/input/input.hpp
+++ b/byuu/input/input.hpp
@@ -58,13 +58,32 @@ private:
 struct VirtualPad {
   VirtualPad();
 
-  InputAxis xAxis{"X-axis"}, yAxis{"Y-axis"};
-  InputButton up{"Up"}, down{"Down"}, left{"Left"}, right{"Right"};
-  InputButton select{"Select"}, start{"Start"};
-  InputButton a{"A"}, b{"B"};
-  InputButton x{"X"}, y{"Y"};
-  InputButton l{"L"}, r{"R"};
-  InputButton cUp{"C-Up"}, cDown{"C-Down"}, cLeft{"C-Left"}, cRight{"C-Right"};
+  InputButton up{"D-Pad.Up"};
+  InputButton down{"D-Pad.Down"};
+  InputButton left{"D-Pad.Left"};
+  InputButton right{"D-Pad.Right"};
+  InputButton a{"A"};
+  InputButton b{"B"};
+  InputButton x{"X"};
+  InputButton y{"Y"};
+  InputButton back{"Back"};
+  InputButton start{"Start"};
+  InputButton lb{"LB"};
+  InputButton lt{"LT"};
+  InputButton rb{"RB"};
+  InputButton rt{"RT"};
+  InputAxis lStickAxisX{"L-Stick.AxisX"};
+  InputAxis lStickAxisY{"L-Stick.AxisY"};
+  InputButton lStickUp{"L-Stick.Up"};
+  InputButton lStickDown{"L-Stick.Down"};
+  InputButton lStickLeft{"L-Stick.Left"};
+  InputButton lStickRight{"L-Stick.Right"};
+  InputAxis rStickAxisX{"R-Stick.AxisX"};
+  InputAxis rStickAxisY{"R-Stick.AxisY"};
+  InputButton rStickUp{"R-Stick.Up"};
+  InputButton rStickDown{"R-Stick.Down"};
+  InputButton rStickLeft{"R-Stick.Left"};
+  InputButton rStickRight{"R-Stick.Right"};
 
   vector<InputMapping*> mappings;
 };

--- a/byuu/settings/input.cpp
+++ b/byuu/settings/input.cpp
@@ -18,7 +18,7 @@ auto InputSettings::construct() -> void {
 
 auto InputSettings::reload() -> void {
   inputList.reset();
-  inputList.append(TableViewColumn().setText("Name"));
+  inputList.append(TableViewColumn().setText("Microsoft Layout"));
   for(uint binding : range(BindingLimit)) {
     inputList.append(TableViewColumn().setText({"Mapping #", 1 + binding}).setExpandable());
   }


### PR DESCRIPTION
-Adds missing Left and Right Trigger mappings
-Adds missing Left and Right Stick mappings
-Removes N64 labels from "Virtual Pad"
-Rebinds N64 C Buttons to Right Thumbstick
-Rebinds N64 Z Trigger from "select button" to "left trigger"
-Renamed default virtual pad mappings to Microsoft labels (no I don't own this pad, but it's definitely the most popular of the 3, and that's why I think it should be default)

I agree with Asura that the Nintendo and Sony mappings should also appear as a dropdown changer or via two additional columns. Someone else can do that as it's beyond my skill. Even if that doesn't get in with this PR, this is still an improvement as it explicitly states "Microsoft layout" in the column header, thus preventing users from assuming it's Nintendo layout and confusing themselves.

Note that the naming of labels had to comply with byuu's bml parser. Spaces, underscores, and parentheses would cause settings to be irretrievable on a new instance. Hyphens and periods were the only okay separators (i.e. R-Stick.Left).