### PR TITLE
Fix XInput trigger button ranges (fixes #108)

### DIFF
--- a/ruby/input/joypad/xinput.cpp
+++ b/ruby/input/joypad/xinput.cpp
@@ -62,14 +62,14 @@ struct InputJoypadXInput {
       assign(jp.hid, HID::Joypad::GroupID::Hat, 0, hatX);
       assign(jp.hid, HID::Joypad::GroupID::Hat, 1, hatY);
 
-      //scale trigger ranges for up to down from (0 to 255) to (-32768 to +32767)
-      uint16_t triggerL = state.Gamepad.bLeftTrigger;
-      uint16_t triggerR = state.Gamepad.bRightTrigger;
-      triggerL = triggerL << 8 | triggerL << 0;
-      triggerR = triggerR << 8 | triggerR << 0;
+      //scale trigger ranges for not-pressed to pressed from (0 to 255) to (0 to +32767)
+      int16_t triggerL = state.Gamepad.bLeftTrigger;
+      int16_t triggerR = state.Gamepad.bRightTrigger;
+      triggerL = triggerL << 7 | triggerL >> 1;
+      triggerR = triggerR << 7 | triggerR >> 1;
 
-      assign(jp.hid, HID::Joypad::GroupID::Trigger, 0, (int16_t)(triggerL - 32768));
-      assign(jp.hid, HID::Joypad::GroupID::Trigger, 1, (int16_t)(triggerR - 32768));
+      assign(jp.hid, HID::Joypad::GroupID::Trigger, 0, triggerL);
+      assign(jp.hid, HID::Joypad::GroupID::Trigger, 1, triggerR);
 
       assign(jp.hid, HID::Joypad::GroupID::Button,  0, (bool)(state.Gamepad.wButtons & XINPUT_GAMEPAD_A));
       assign(jp.hid, HID::Joypad::GroupID::Button,  1, (bool)(state.Gamepad.wButtons & XINPUT_GAMEPAD_B));


### PR DESCRIPTION
It dawned on me that with a very minor change we could fix this correctly, and in all three GUIs at once!

The problem is that the axis and trigger handling are the same in the emulators. 0 is considered neutral (not pressed), -32768 is considered pressed in one direction, and +32767 is considered pressed in the other direction. That works great for a stick that can move both ways. But a trigger only moves in one way. So if we use the range 0 to +32767, then assigning the trigger will always do the right thing and choose Trigger.Hi, and 0 will be seen as neutral or not pressed. Whereas before, using the range -32768 to +32767, it would sense Trigger.Lo since you started changing the input value while it was negative.