### PR TITLE
ps1: cache isolate bit should isolate i-cache, not d-cache (scratchpad)

### DIFF
--- a/higan/ps1/cpu/core/memory.cpp
+++ b/higan/ps1/cpu/core/memory.cpp
@@ -1,29 +1,29 @@
 inline auto CPU::readByte(u32 address) -> u32 {
-  if(scc.status.cache.isolate) return cache.readByte(address);
+  if(scc.status.cache.isolate) return icache.readByte(address);
   return bus.readByte(address);
 }
 
 inline auto CPU::readHalf(u32 address) -> u32 {
-  if(scc.status.cache.isolate) return cache.readHalf(address);
+  if(scc.status.cache.isolate) return icache.readHalf(address);
   return bus.readHalf(address);
 }
 
 inline auto CPU::readWord(u32 address) -> u32 {
-  if(scc.status.cache.isolate) return cache.readWord(address);
+  if(scc.status.cache.isolate) return icache.readWord(address);
   return bus.readWord(address);
 }
 
 inline auto CPU::writeByte(u32 address, u32 data) -> void {
-  if(scc.status.cache.isolate) return cache.writeByte(address, data);
+  if(scc.status.cache.isolate) return icache.writeByte(address, data);
   return bus.writeByte(address, data);
 }
 
 inline auto CPU::writeHalf(u32 address, u32 data) -> void {
-  if(scc.status.cache.isolate) return cache.writeHalf(address, data);
+  if(scc.status.cache.isolate) return icache.writeHalf(address, data);
   return bus.writeHalf(address, data);
 }
 
 inline auto CPU::writeWord(u32 address, u32 data) -> void {
-  if(scc.status.cache.isolate) return cache.writeWord(address, data);
+  if(scc.status.cache.isolate) return icache.writeWord(address, data);
   return bus.writeWord(address, data);
 }

--- a/higan/ps1/cpu/cpu.cpp
+++ b/higan/ps1/cpu/cpu.cpp
@@ -10,13 +10,15 @@ CPU cpu;
 auto CPU::load(Node::Object parent) -> void {
   node = parent->append<Node::Component>("CPU");
   ram.allocate(2_MiB);
-  cache.allocate(1_KiB);
+  dcache.allocate(1_KiB);
+  icache.allocate(4_KiB);
   debugger.load(node);
 }
 
 auto CPU::unload() -> void {
   debugger = {};
-  cache.reset();
+  dcache.reset();
+  icache.reset();
   ram.reset();
   node.reset();
 }
@@ -44,7 +46,8 @@ auto CPU::power(bool reset) -> void {
   Thread::reset();
   powerCore(reset);
   ram.fill();
-  cache.fill();
+  dcache.fill();
+  icache.fill();
 }
 
 }

--- a/higan/ps1/cpu/cpu.hpp
+++ b/higan/ps1/cpu/cpu.hpp
@@ -3,7 +3,8 @@
 struct CPU : Thread {
   Node::Component node;
   Memory::Writable ram;
-  Memory::Writable cache;
+  Memory::Writable dcache;
+  Memory::Writable icache;
 
   struct Debugger {
     //debugger.cpp
@@ -24,7 +25,8 @@ struct CPU : Thread {
 
     struct Memory {
       Node::Memory ram;
-      Node::Memory cache;
+      Node::Memory dcache;
+      Node::Memory icache;
     } memory;
   } debugger;
 

--- a/higan/ps1/cpu/debugger.cpp
+++ b/higan/ps1/cpu/debugger.cpp
@@ -16,13 +16,22 @@ auto CPU::Debugger::load(Node::Object parent) -> void {
     return cpu.ram.writeByte(address, data);
   });
 
-  memory.cache = parent->append<Node::Memory>("CPU Cache");
-  memory.cache->setSize(cpu.cache.size);
-  memory.cache->setRead([&](uint32 address) -> uint8 {
-    return cpu.cache.readByte(address);
+  memory.dcache = parent->append<Node::Memory>("CPU Data Cache");
+  memory.dcache->setSize(cpu.dcache.size);
+  memory.dcache->setRead([&](uint32 address) -> uint8 {
+    return cpu.dcache.readByte(address);
   });
-  memory.cache->setWrite([&](uint32 address, uint8 data) -> void {
-    return cpu.cache.writeByte(address, data);
+  memory.dcache->setWrite([&](uint32 address, uint8 data) -> void {
+    return cpu.dcache.writeByte(address, data);
+  });
+
+  memory.icache = parent->append<Node::Memory>("CPU Instruction Cache");
+  memory.icache->setSize(cpu.icache.size);
+  memory.icache->setRead([&](uint32 address) -> uint8 {
+    return cpu.icache.readByte(address);
+  });
+  memory.icache->setWrite([&](uint32 address, uint8 data) -> void {
+    return cpu.icache.writeByte(address, data);
   });
 }
 

--- a/higan/ps1/memory/bus.hpp
+++ b/higan/ps1/memory/bus.hpp
@@ -4,7 +4,7 @@
   if(address <= 0x001f'ffff) return cpu.ram.access(__VA_ARGS__); \
   if(address <= 0x1eff'ffff) return unmapped; \
   if(address <= 0x1f7f'ffff) return unmapped; \
-  if(address <= 0x1f80'03ff) return cpu.cache.access(__VA_ARGS__); \
+  if(address <= 0x1f80'03ff) return cpu.dcache.access(__VA_ARGS__); \
   if(address <= 0x1f80'103f) return unmapped; \
   if(address <= 0x1f80'104f) return peripheral.access(__VA_ARGS__); \
   if(address <= 0x1f80'106f) return unmapped; \


### PR DESCRIPTION
One obvious improvement is that this solves the 'black road' issue in Ridge Racer (note that the broken polygons are part of an unrelated problem)

As this is such a fundamental flaw, chances are there are significant improvements to other games too.

before:
![before](https://user-images.githubusercontent.com/740003/94830663-b6031380-0403-11eb-9ffb-6b177318c087.png)

after:
![after](https://user-images.githubusercontent.com/740003/94830684-bac7c780-0403-11eb-8d6c-3d4dafce4da0.png)
