### PR TITLE
Implement GitHub Actions based CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,204 @@
+name: Build
+on:
+  push:
+    branches: [ master ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  build:
+    strategy:
+      matrix:
+        program:
+        - higan-ui
+        - byuu
+        - icarus
+        os:
+        - name: ubuntu
+          version: latest
+        - name: windows
+          version: latest
+        - name: macos
+          version: latest
+    runs-on: ${{ matrix.os.name }}-${{ matrix.os.version }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Dependencies
+      if: matrix.os.name == 'ubuntu'
+      run: |
+        sudo apt-get update -y -qq
+        sudo apt-get install libsdl2-dev libgtksourceview2.0-dev libgtk2.0-dev libao-dev libopenal-dev
+    - name: Make
+      run: make -j4 -C ${{ matrix.program }} build=performance local=false
+    - name: Upload
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.program }}-${{ matrix.os.name }}
+        path: ${{ matrix.program }}/out/${{ matrix.program }}*
+
+  release:
+    if: github.event.action != 'pull_request'
+    runs-on: ubuntu-latest
+    needs:
+    - build
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: 'src'
+    - name: Download Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        path: 'bin'
+    - name: Package Artifacts
+      run: |
+        set -eu
+        case ${GITHUB_REF} in
+          refs/tags/*) suffix="-${GITHUB_REF#refs/tags/}" ;;
+          refs/heads/master) suffix="-nightly" ;;
+          *) suffix="" ;;
+        esac
+
+        srcdir="${GITHUB_WORKSPACE}/src"
+        bindir="${GITHUB_WORKSPACE}/bin"
+
+        # Hack: Workaround for GitHub artifacts losing attributes.
+        for program in higan-ui icarus byuu
+        do
+          chmod +x ${bindir}/${program}-ubuntu/${program}
+          chmod +x ${bindir}/${program}-macos/${program}.app/Contents/MacOS/${program}
+        done
+
+        for os in ubuntu windows macos
+        do
+          mkdir "${os}"
+          cd "${os}"
+
+          # Package higan.
+          outdir=higan${suffix}
+          mkdir ${outdir}
+          mkdir ${outdir}/Systems
+          cp -ar ${bindir}/higan-ui-${os}/* ${outdir}
+          cp -ar ${bindir}/icarus-${os}/* ${outdir}
+          cp -a ${srcdir}/higan/System ${outdir}/Templates
+          cp -a ${srcdir}/icarus/Database ${outdir}
+          cp -a ${srcdir}/icarus/Firmware ${outdir}
+          cp -a ${srcdir}/GPLv3.txt ${outdir}
+          cp -a ${srcdir}/extras/higan/* ${outdir}
+          cp -a ${srcdir}/extras/both/* ${outdir}
+          zip -r ../higan-${os}.zip ${outdir}
+
+          # Package byuu.
+          outdir=byuu${suffix}
+          mkdir ${outdir}
+          mkdir ${outdir}/Firmware
+          cp -ar ${bindir}/byuu-${os}/* ${outdir}
+          cp -a ${srcdir}/GPLv3.txt ${outdir}
+          cp -a ${srcdir}/extras/byuu/* ${outdir}
+          cp -a ${srcdir}/extras/both/* ${outdir}
+          zip -r ../byuu-${os}.zip ${outdir}
+
+          cd -
+        done
+    - name: Create Release
+      id: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -eu
+        github_rest()
+        {
+          local method="${1}"
+          local url="https://api.github.com${2}"
+          shift 2
+          >&2 echo "${method} ${url}"
+          curl \
+            --fail \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            -X "${method}" \
+            "${url}" \
+            "$@"
+        }
+        github_get_release_id_for_tag()
+        {
+          payload=$(github_rest GET "/repos/${GITHUB_REPOSITORY}/releases/tags/${1}") || return
+          echo "${payload}" | jq .id
+        }
+        github_delete_release_by_id()
+        {
+          github_rest DELETE "/repos/${GITHUB_REPOSITORY}/releases/${1}"
+        }
+        github_create_release()
+        {
+          local payload="{
+            \"tag_name\": \"${1}\",
+            \"target_commitish\": \"${2}\",
+            \"name\": \"${3}\",
+            \"body\": \"${4}\",
+            \"draft\": ${5},
+            \"prerelease\": ${6}
+          }"
+          github_rest POST "/repos/${GITHUB_REPOSITORY}/releases" -d "${payload}"
+        }
+        make_nightly_release()
+        {
+          github_create_release \
+            nightly \
+            "${GITHUB_SHA}" \
+            "higan nightly $(date +"%Y-%m-%d")" \
+            "Auto-generated nightly release on $(date -u +"%Y-%m-%d %T %Z")" \
+            false \
+            true
+        }
+        make_version_release()
+        {
+          github_create_release \
+            "${1}" \
+            "${GITHUB_SHA}" \
+            "higan ${1}" \
+            "This is higan ${1}, released on $(date +"%Y-%m-%d")." \
+            false \
+            false
+        }
+        case ${GITHUB_REF} in
+          refs/tags/*)
+            # Create a new version release using the current revision.
+            echo "UPLOAD_URL=$(make_version_release ${GITHUB_REF#refs/tags/} | jq -r .upload_url)" >> $GITHUB_ENV
+            ;;
+          refs/heads/master)
+            # Check for an existing nightly release.
+            { release_id=$(github_get_release_id_for_tag nightly); status=$?; } || true
+            # Delete existing nightly release if it exists.
+            case ${status} in
+              0) github_delete_release_by_id "${release_id}" ;;
+              22) >&2 echo "No current nightly release; skipping tag deletion." ;;
+              *) >&2 echo "API call failed unexpectedly." && exit 1 ;;
+            esac
+            # Create a new nightly release using the current revision.
+            echo "UPLOAD_URL=$(make_nightly_release | jq -r .upload_url)" >> $GITHUB_ENV
+            ;;
+        esac
+    - name: Upload higan-ubuntu
+      uses: actions/upload-release-asset@v1
+      env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }
+      with: { upload_url: '${{ env.UPLOAD_URL }}', asset_path: 'higan-ubuntu.zip', asset_name: 'higan-ubuntu.zip', asset_content_type: 'application/zip' }
+    - name: Upload byuu-ubuntu
+      uses: actions/upload-release-asset@v1
+      env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }
+      with: { upload_url: '${{ env.UPLOAD_URL }}', asset_path: 'byuu-ubuntu.zip', asset_name: 'byuu-ubuntu.zip', asset_content_type: 'application/zip' }
+    - name: Upload higan-windows
+      uses: actions/upload-release-asset@v1
+      env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }
+      with: { upload_url: '${{ env.UPLOAD_URL }}', asset_path: 'higan-windows.zip', asset_name: 'higan-windows.zip', asset_content_type: 'application/zip' }
+    - name: Upload byuu-windows
+      uses: actions/upload-release-asset@v1
+      env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }
+      with: { upload_url: '${{ env.UPLOAD_URL }}', asset_path: 'byuu-windows.zip', asset_name: 'byuu-windows.zip', asset_content_type: 'application/zip' }
+    - name: Upload higan-macos
+      uses: actions/upload-release-asset@v1
+      env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }
+      with: { upload_url: '${{ env.UPLOAD_URL }}', asset_path: 'higan-macos.zip', asset_name: 'higan-macos.zip', asset_content_type: 'application/zip' }
+    - name: Upload byuu-macos
+      uses: actions/upload-release-asset@v1
+      env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' }
+      with: { upload_url: '${{ env.UPLOAD_URL }}', asset_path: 'byuu-macos.zip', asset_name: 'byuu-macos.zip', asset_content_type: 'application/zip' }


### PR DESCRIPTION
# Summary
This pull request implements a continuous build process for building Higan.

## Features
- Implements native builds for Ubuntu, Windows and macOS.
- Builds Higan piece-wise by running a matrix over the programs (higan-ui, byuu, icarus) and the OS (for a total of 9 jobs.)
- Produces a "nightly" build release that is continuously updated with the latest binaries. This gives a consistent URL to get the latest nightly build. See, for example, on my fork: https://github.com/jchw-forks/higan/releases/tag/nightly
- Produces a version release on each tag starting with v. For example, see https://github.com/jchw-forks/higan/releases/tag/v116. (We could make this a draft so release notes can be edited and a release could be manually published, too, but right now it just publishes the release immediately.)

# Design

## The Matrix
The build matrix has two dimensions: the programs (higan-ui, byuu, icarus) and the OS (ubuntu, windows, and macos.) The builder always passes `build=performance` and `local=false` to the `make` invocation. Unlike Cirrus CI, we do not set the `profile` value at all, since it defaults to what is expected for each UI anyways.

`local=false` is needed because some workers arbitrarily have a newer Xeon that supports AVX512, which has two undesirable side-effects:

- Versions of GCC earlier than 8.4 fail due to an issue with handling the XMM16-31 registers. The builders have GCC 8.1.
- Binaries produced by these workers will not run on machines without AVX512, which is a significant portion of users.

In any case, this was already set by the Cirrus CI runner, and is idiomatically the correct thing to do, but those caveats are especially worth mentioning here.

## Packaging
GitHub's artifacts mechanism is a little tricky at first. The first interesting behavior is that within a single workflow, artifacts with the same name are merged into one unit. The second interesting behavior is that we can download all artifacts at once, and each will appear in a subdirectory with the name of the artifact in the path we request (it defaults to `$GITHUB_WORKSPACE` which is, coincidentally, also the default `$PWD`.)

Packaging varies between `higan-ui` and `byuu`, but it doesn't actually vary by much between platforms. In fact, here the packaging code is actually identical across platforms, and so we just loop over each platform and do the same exact thing.

## Release Step
GitHub has some helper actions, written using their platform-agnostic JavaScript action runner, that can perform certain tasks for you, like create a new release. Unfortunately, we need to do some things that do not fit well within the capabilities available from existing actions. (I will detail exactly what those are in a moment.) In interest of broader maintainability, my initial code which did work in TypeScript has been ported to shell script and subsequently merged into the workflow itself.

Much of what is needed to make GitHub REST API calls across platforms is pretty consistent across different endpoints, so we define a function `github_rest` which takes an HTTP method (sometimes known as a verb) and a path, and then forwards remaining arguments to `curl`. Authentication and API versioning are handled within `github_rest` to reduce duplication. We use cURL's `--fail` mode to make server errors return errors, which, using `errquit`, should propagate up to a build failure.

Helper functions do actual GitHub API calls, like `github_get_release_id_for_tag`. We parse JSON using `jq` which is preinstalled on GitHub Action's Ubuntu runner. Since pipelines effectively bypass `errquit`, we capture the output into a variable and run `jq` separately; it might be possible to do this in a less awful fashion. Some other `errquit` workaround shenanigans appear in the code as well; when in doubt, assume the weird thing I'm doing is working around subtle shell behavior.

Finally, the release step passes the upload URL for artifacts into `UPLOAD_URL` using the GitHub Runner environment file mechanism, and this can then be used by subsequent stages to upload the artifacts.

## Nightly Release
GitHub Actions artifacts are useful, but they come with caveats.
- They have a retention of 6 months. (This is not actually bad, but it's worth noting.)
- They are inaccessible by users who are not authenticated with GitHub.
- There is no consistent URL to get the latest build for a branch.

We would ideally like to have a static URL for the latest build, and also, it would be ideal if said builds were available even to people without GitHub accounts. Therefore, it is ideal to have a 'rolling' nightly release that is updated on every push to `master`.

To facilitate this, the bash code aforementioned _deletes and recreates_ a release with the `nightly` tag on every build, and then new build artifacts are attached to that.

This does have the downside of being very noisy for users who are trying to watch the repository using the "Releases Only" option, although it has little effect for ordinary watchers who would see pull request merges anyways.

# Performance
Compared to Cirrus CI, builds are faster. There is also slightly more parallelism, as Icarus is compiled in a separate VM, although this is more a move to simplify the code than it is to improve performance.

Since GitHub Actions limits concurrency to 8 simultaneous jobs, one job will start stalled, but it will only take a minute or two for it to pick up. Typical runtimes look like around 17 minutes from start to finish. macOS jobs are the fastest, although also seem to be fairly variable.

# Comparing to Cirrus CI
This setup has some disadvantages to the current Cirrus CI setup:

- We lack a path to support FreeBSD, at least easily. Cross-compilation is a potential avenue, but people seem skeptical about whether or not a FreeBSD CI is desirable without byuu around. I would like to support it just to ensure the code stays FreeBSD compatible, since there is little sense in not.
- Only the latest nightly build is kept. There *are* build artifacts for the remaining builds, but they are not nicely packaged binaries like the release downloads, and they require authentication. That said, it should be possible to reconcile some of this, with a little bit uglier code.
- Currently the release is all-or-nothing, whereas if some targets failed on Cirrus CI it would be easy to grab the latest build for at least the successful jobs.

It has some advantages as well:

- It performs better; almost twice as fast seemingly.
- It is built-in on GitHub, and therefore governance is somewhat simplified and a bit more community-controlled.
- It offers some better integration with GitHub.

Above all, the primary advantage that seems to make it appealing is just the simplicity. Cirrus CI is fine, but it is another 'thing.' If it can be dropped, it is one less 'thing' to worry about.

Currently, I believe we should continue running both CIs simultaneously for a period of time.