### PR TITLE
Prevent GitHub Actions from releasing on PRs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         path: ${{ matrix.program }}/out/${{ matrix.program }}*
 
   release:
-    if: github.event.action != 'pull_request'
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs:
     - build


### PR DESCRIPTION
This is a bit trickier than expected, but it basically encapsulates the desired logic; it checks to see if we're on a ref that we would want to release for. There seems to be no good way to detect PRs; the previous code was a sham I copy-pasted without validating.

See it in action here:
- Running on master: https://github.com/jchw-forks/higan/actions/runs/300278278
- Running on a PR: https://github.com/jchw-forks/higan/actions/runs/300281344
