### PR TITLE
Z80 fixes

### DIFF
--- a/higan/component/processor/z80/memory.cpp
+++ b/higan/component/processor/z80/memory.cpp
@@ -59,13 +59,13 @@ auto Z80::write(uint16 addr, uint8 data) -> void {
   return bus->write(addr, data);
 }
 
-auto Z80::in(uint8 addr) -> uint8 {
+auto Z80::in(uint16 addr) -> uint8 {
   yield();
   step(4);
   return bus->in(addr);
 }
 
-auto Z80::out(uint8 addr, uint8 data) -> void {
+auto Z80::out(uint16 addr, uint8 data) -> void {
   yield();
   step(4);
   return bus->out(addr, data);

--- a/higan/component/processor/z80/z80.cpp
+++ b/higan/component/processor/z80/z80.cpp
@@ -25,6 +25,7 @@ auto Z80::power(MOSFET mosfet) -> void {
 
 auto Z80::irq(bool maskable, uint16 pc, uint8 extbus) -> bool {
   if(maskable && !IFF1) return false;
+  wait(7);
   R.bit(0,6)++;
 
   push(PC);

--- a/higan/component/processor/z80/z80.hpp
+++ b/higan/component/processor/z80/z80.hpp
@@ -51,8 +51,8 @@ struct Z80 {
   auto displace(uint16&) -> uint16;
   auto read(uint16 addr) -> uint8;
   auto write(uint16 addr, uint8 data) -> void;
-  auto in(uint8 addr) -> uint8;
-  auto out(uint8 addr, uint8 data) -> void;
+  auto in(uint16 addr) -> uint8;
+  auto out(uint16 addr, uint8 data) -> void;
 
   //instruction.cpp
   auto instruction() -> void;


### PR DESCRIPTION
A couple of fixes to the Z80 core that are required for ZX Spectrum emulation: 

1. The Z80 exports 16-bit values on the IO bus, but Higan was clamping to 8-bit, perhaps unintentionally, as the external bus interface (bus->in/bus->out) was already using 16-bit values.
2. Interrupts have a 7 cycle acknowledge delay. 