### PR TITLE
higan: fix invalid "Application Support" path on macOS

### DIFF
--- a/higan-ui/GNUmakefile
+++ b/higan-ui/GNUmakefile
@@ -73,9 +73,8 @@ else ifeq ($(shell id -un),root)
 	$(error "make install should not be run as root")
 else ifeq ($(platform),macos)
 	mkdir -p ~/Library/Application\ Support/$(name)/
-	mkdir -p ~/Library/Application\ Support/$(name)/System/
 	cp -R $(output.path)/$(name).app /Applications/$(name).app
-	cp -R $(higan.path)/System/* ~/Library/Application\ Support/$(name)/System/
+	cp -R $(higan.path)/System/* ~/Library/Application\ Support/$(name)/
 else ifneq ($(filter $(platform),linux bsd),)
 	mkdir -p $(prefix)/bin/
 	mkdir -p $(prefix)/share/applications/

--- a/higan-ui/GNUmakefile
+++ b/higan-ui/GNUmakefile
@@ -72,8 +72,8 @@ ifeq ($(platform),windows)
 else ifeq ($(shell id -un),root)
 	$(error "make install should not be run as root")
 else ifeq ($(platform),macos)
-	mkdir -p ~/Library/Application\ Support\$(name)/
-	mkdir -p ~/Library/Application\ Support\$(name)/System/
+	mkdir -p ~/Library/Application\ Support/$(name)/
+	mkdir -p ~/Library/Application\ Support/$(name)/System/
 	cp -R $(output.path)/$(name).app /Applications/$(name).app
 	cp -R $(higan.path)/System/* ~/Library/Application\ Support/$(name)/System/
 else ifneq ($(filter $(platform),linux bsd),)


### PR DESCRIPTION
Fix an issue where the Higan template directory was created as `~/Library/Application Supporthigan-ui/` rather than `~/Library/Application Support/higan-ui/` due to a typo in the install makefile target.

The second commit in this PR fixes an issue where templates were copied to `~/Library/Application Support/higan-ui/System/`  where the higan-ui application was searching for templates in `~/Library/Application Support/higan-ui/`

With this PR, higan-ui works as expected after running `make install` on a macOS target.