### PR TITLE
mac: Quit higan when 'Quit' is selected in the main menu bar

### DIFF
--- a/higan-ui/program/program.cpp
+++ b/higan-ui/program/program.cpp
@@ -104,6 +104,10 @@ Program::Program() {
   setTitle({"higan-ui v", higan::Version});
   setVisible();
 
+  #if defined(PLATFORM_MACOS)
+    Application::Cocoa::onQuit([&] { emulator.quit(); });
+  #endif
+
   emulator.inputUpdate();
   videoSettings.eventChange();
   audioSettings.eventChange();


### PR DESCRIPTION
Fixes an issue where higan-ui would not exit when 'Quit' is selected in the Mac menu bar.

byuu/icarus were already working as expected, so didn't need a patch.