### PR TITLE
hiro: Defer menubar updates on Windows to reduce flicker.

### DIFF
--- a/hiro/windows/application.cpp
+++ b/hiro/windows/application.cpp
@@ -3,6 +3,7 @@
 namespace hiro {
 
 static auto Application_keyboardProc(HWND, UINT, WPARAM, LPARAM) -> bool;
+static auto Application_processDeferred() -> void;
 static auto Application_processDialogMessage(MSG&) -> void;
 static auto CALLBACK Window_windowProc(HWND, UINT, WPARAM, LPARAM) -> LRESULT;
 
@@ -44,6 +45,14 @@ auto pApplication::processEvents() -> void {
       Application_processDialogMessage(msg);
     }
   }
+  Application_processDeferred();
+}
+
+auto Application_processDeferred() -> void {
+  for (auto menu : pApplication::state().staleMenus) {
+    menu->_updateDeferred();
+  }
+  pApplication::state().staleMenus.reset();
 }
 
 auto Application_processDialogMessage(MSG& msg) -> void {

--- a/hiro/windows/application.hpp
+++ b/hiro/windows/application.hpp
@@ -17,6 +17,7 @@ struct pApplication {
     int modalCount = 0;           //number of modal loops
     Timer modalTimer;             //to run Application during modal events
     pToolTip* toolTip = nullptr;  //active toolTip
+    vector<pMenuBar*> staleMenus; //menubars to update
   };
   static auto state() -> State&;
 };

--- a/hiro/windows/menu-bar.cpp
+++ b/hiro/windows/menu-bar.cpp
@@ -7,6 +7,7 @@ auto pMenuBar::construct() -> void {
 }
 
 auto pMenuBar::destruct() -> void {
+  pApplication::state().staleMenus.removeByValue(this);
   if(hmenu) { DestroyMenu(hmenu); hmenu = nullptr; }
   if(auto parent = _parent()) {
     SetMenu(parent->hwnd, nullptr);
@@ -44,6 +45,20 @@ auto pMenuBar::_parent() -> maybe<pWindow&> {
 }
 
 auto pMenuBar::_update() -> void {
+  bool updateNow = false;
+  if(auto parent = _parent()) {
+    updateNow = GetMenu(parent->hwnd) == nullptr;
+  }
+  
+  if (updateNow) {
+    _updateDeferred();
+  } else {
+    pApplication::state().staleMenus.removeByValue(this);
+    pApplication::state().staleMenus.append(this);
+  }
+}
+
+auto pMenuBar::_updateDeferred() -> void {
   if(hmenu) DestroyMenu(hmenu);
   hmenu = CreateMenu();
 

--- a/hiro/windows/menu-bar.hpp
+++ b/hiro/windows/menu-bar.hpp
@@ -13,6 +13,7 @@ struct pMenuBar : pObject {
 
   auto _parent() -> maybe<pWindow&>;
   auto _update() -> void;
+  auto _updateDeferred() -> void;
 
   HMENU hmenu = 0;
   vector<wObject> objects;


### PR DESCRIPTION
Menu bar updates are deferred to the event loop. A special case is made when no menu bar is visible, to ensure one is visible as early as possible during application startup.


| Old| New |
| --- | --- |
|  ![byuu with current hiro, menu flickers](https://user-images.githubusercontent.com/938744/99338510-2e4d5900-2839-11eb-9830-0e5f135a6109.gif) | ![byuu with hiro from this PR, no menu flicker](https://user-images.githubusercontent.com/938744/99338518-31484980-2839-11eb-96b1-7ad746cfe90a.gif) |