### PR TITLE
Clean Code M68K

### DIFF
--- a/higan/component/processor/m68k/m68k.cpp
+++ b/higan/component/processor/m68k/m68k.cpp
@@ -3,9 +3,6 @@
 
 namespace higan {
 
-enum : uint { Byte, Word, Long };
-enum : bool { Reverse = 1, Extend = 1, Hold = 1, Fast = 1 };
-
 #include "registers.cpp"
 #include "memory.cpp"
 #include "effective-address.cpp"

--- a/higan/component/processor/m68k/m68k.cpp
+++ b/higan/component/processor/m68k/m68k.cpp
@@ -4,7 +4,7 @@
 namespace higan {
 
 enum : uint { Byte, Word, Long };
-enum : bool { Reverse = 1 };
+enum : bool { Reverse = 1, Extend = 1, Hold = 1, Fast = 1 };
 
 #include "registers.cpp"
 #include "memory.cpp"

--- a/higan/component/processor/m68k/m68k.hpp
+++ b/higan/component/processor/m68k/m68k.hpp
@@ -4,6 +4,10 @@
 
 namespace higan {
 
+enum : uint { Byte, Word, Long };
+enum : bool { Reverse = 1, Extend = 1, Hold = 1, Fast = 1 };
+enum : bool { User, Supervisor };
+
 struct M68K {
   virtual auto idle(uint clocks) -> void = 0;
   virtual auto wait(uint clocks) -> void = 0;
@@ -11,10 +15,6 @@ struct M68K {
   virtual auto write(uint1 upper, uint1 lower, uint24 address, uint16 data) -> void = 0;
 
   auto ird() const -> uint16 { return r.ird; }
-
-  enum : bool { User, Supervisor };
-  enum : uint { Byte, Word, Long };
-  enum : bool { Reverse = 1, Extend = 1, Hold = 1, Fast = 1 };
 
   enum : uint {
     /* 0,n */ DataRegisterDirect,


### PR DESCRIPTION
2 Enum was declared 2 times.
1 time in M68K;hpp
One time in M68K.cpp
One enum in M68K.hpp (in higan space) is sufficient and more clean.