### PR TITLE
[Mega CD] fix sub-CPU WRAM switching behavior [TascoDLX]

### DIFF
--- a/higan/md/mcd/io.cpp
+++ b/higan/md/mcd/io.cpp
@@ -201,7 +201,7 @@ auto MCD::writeIO(uint1 upper, uint1 lower, uint24 address, uint16 data) -> void
       io.wramSelect   = data.bit(0);
       io.wramMode     = data.bit(2);
       io.wramPriority = data.bit(3,4);
-      io.wramSwitch   = 0;
+      if(io.wramSelect) io.wramSwitch = 0;
     }
   }
 


### PR DESCRIPTION
WRAM should only be switched back when writing a 1-bit to $ff8003.d0 (RET bit) for the Mega CD.
This fix allows Popful Mail to boot and be mostly playable.