### PR TITLE
[Mega CD] fix bitrange for CDC transfer destination writes [TascoDLX]

### DIFF
--- a/higan/md/mcd/io.cpp
+++ b/higan/md/mcd/io.cpp
@@ -210,7 +210,7 @@ auto MCD::writeIO(uint1 upper, uint1 lower, uint24 address, uint16 data) -> void
       cdc.address = data.bit(0,3);
     }
     if(upper) {
-      cdc.transfer.destination = data.bit(0,2);
+      cdc.transfer.destination = data.bit(8,10);
     }
   }
 


### PR DESCRIPTION
This change fixes a bad bit-range on $ff8004 writes, which fixes the game Radical Rex.
Before it would hang at the title screen, and now the game is playable.