### PR TITLE
MegaDrive+Z80 fixes

### DIFF
--- a/higan/component/processor/z80/instruction.cpp
+++ b/higan/component/processor/z80/instruction.cpp
@@ -22,7 +22,7 @@ auto Z80::instruction() -> void {
 
   if(code == 0xcb && prefix != Prefix::hl) {
     WZ = HL + (int8)operand();
-    wait(1);
+    wait(2); // +1 fetch, +1 memory read
   //R is not incremented here
     instructionCBd(WZ, opcode());
   } else if(code == 0xcb) {

--- a/higan/component/processor/z80/z80.cpp
+++ b/higan/component/processor/z80/z80.cpp
@@ -24,7 +24,7 @@ auto Z80::power(MOSFET mosfet) -> void {
 }
 
 auto Z80::irq(bool maskable, uint16 pc, uint8 extbus) -> bool {
-  if(maskable && !IFF1) return false;
+  if((maskable && !IFF1) || EI) return false;
   wait(7);
   R.bit(0,6)++;
 

--- a/higan/component/processor/z80/z80.cpp
+++ b/higan/component/processor/z80/z80.cpp
@@ -25,7 +25,7 @@ auto Z80::power(MOSFET mosfet) -> void {
 
 auto Z80::irq(bool maskable, uint16 pc, uint8 extbus) -> bool {
   if((maskable && !IFF1) || EI) return false;
-  wait(7);
+  uint cycles;
   R.bit(0,6)++;
 
   push(PC);
@@ -35,12 +35,14 @@ auto Z80::irq(bool maskable, uint16 pc, uint8 extbus) -> bool {
   case 0: {
     //external data bus ($ff = RST $38)
     WZ = extbus;
+    cycles = extbus|0x38 == 0xFF ? 6 : 7;
     break;
   }
 
   case 1: {
     //constant address
     WZ = pc;
+    cycles = maskable ? 7 : 5;
     break;
   }
 
@@ -49,6 +51,7 @@ auto Z80::irq(bool maskable, uint16 pc, uint8 extbus) -> bool {
     uint16 addr = I << 8 | extbus;
     WZL = read(addr + 0);
     WZH = read(addr + 1);
+    cycles = 7;
     break;
   }
 
@@ -61,6 +64,8 @@ auto Z80::irq(bool maskable, uint16 pc, uint8 extbus) -> bool {
   if(P) PF = 0;
   P = 0;
   Q = 0;
+
+  wait(cycles);
   return true;
 }
 

--- a/higan/md/apu/apu.cpp
+++ b/higan/md/apu/apu.cpp
@@ -62,17 +62,21 @@ auto APU::enable(bool value) -> void {
 auto APU::power(bool reset) -> void {
   Z80::bus = this;
   Z80::power();
+  ym2612.power(reset);
   bus->grant(false);
   Thread::create(system.frequency() / 15.0, {&APU::main, this});
   if(!reset) ram.allocate(8_KiB);
   state = {};
+  io = {};
 }
 
 auto APU::reset() -> void {
   Z80::power();
+  ym2612.power(true);
   bus->grant(false);
   Thread::create(system.frequency() / 15.0, {&APU::main, this});
   state = {};
+  io = {};
 }
 
 }

--- a/higan/md/apu/serialization.cpp
+++ b/higan/md/apu/serialization.cpp
@@ -7,7 +7,9 @@ auto APU::serialize(serializer& s) -> void {
 
   s.integer(io.bank);
 
-  s.integer(state.enabled);
+  s.integer(arbstate.resetLine);
+  s.integer(arbstate.busreqLine);
+  s.integer(arbstate.busreqLatch);
   s.integer(state.nmiLine);
   s.integer(state.intLine);
 }

--- a/higan/md/cpu/bus.cpp
+++ b/higan/md/cpu/bus.cpp
@@ -26,7 +26,7 @@ auto CPU::read(uint1 upper, uint1 lower, uint24 address, uint16 data) -> uint16 
   }
 
   if(address >= 0xa00000 && address <= 0xa0ffff) {
-    if(!apu.granted()) return data;
+    if(apu.busStatus()) return data;
     address.bit(15) = 0;  //a080000-a0ffff mirrors a00000-a07fff
     //word reads load the even input byte into both output bytes
     auto byte = apu.read(address | !upper);  //upper==0 only on odd byte reads
@@ -79,7 +79,7 @@ auto CPU::write(uint1 upper, uint1 lower, uint24 address, uint16 data) -> void {
   }
 
   if(address >= 0xa00000 && address <= 0xa0ffff) {
-    if(!apu.granted()) return;
+    if(apu.busStatus()) return;
     address.bit(15) = 0;  //a08000-a0ffff mirrors a00000-a07fff
     //word writes store the upper input byte into the lower output byte
     return apu.write(address | !upper, data.byte(upper));  //upper==0 only on odd byte reads

--- a/higan/md/cpu/io.cpp
+++ b/higan/md/cpu/io.cpp
@@ -42,7 +42,7 @@ auto CPU::readIO(uint1 upper, uint1 lower, uint24 address, uint16 data) -> uint1
   }
 
   if(address >= 0xa11100 && address <= 0xa111ff) {
-    data.byte(1) = !apu.granted();
+    data.bit(8) = apu.busStatus();
     return data;
   }
 
@@ -85,13 +85,13 @@ auto CPU::writeIO(uint1 upper, uint1 lower, uint24 address, uint16 data) -> void
 
   if(address >= 0xa11100 && address <= 0xa111ff) {
     if(!upper) return;  //unconfirmed
-    apu.request(data.bit(8));
+    apu.setBREQ(data.bit(8));
     return;
   }
 
   if(address >= 0xa11200 && address <= 0xa112ff) {
     if(!upper) return;  //unconfirmed
-    apu.enable(data.bit(8));
+    apu.setRES(data.bit(8));
     return;
   }
 

--- a/higan/md/system/system.cpp
+++ b/higan/md/system/system.cpp
@@ -103,13 +103,19 @@ auto System::power(bool reset) -> void {
 
   random.entropy(Random::Entropy::Low);
 
+  if(!reset) {
+    controllerPort1.power();
+    controllerPort2.power();
+    extensionPort.power();
+  }
+
   if(cartridge.node) cartridge.power();
   if(expansion.node) expansion.power();
   cpu.power(reset);
   apu.power(reset);
+  //ym2612.power(reset); // YM2612 reset is tied to Z80 reset line (!ZRES)
   vdp.power(reset);
-  psg.power(reset);
-  ym2612.power(reset);
+  //psg.power(reset); // MD has PSG (SN76489) integrated into the VDP
   if(MegaCD()) mcd.power(reset);
   scheduler.power(cpu);
 

--- a/higan/md/vdp/vdp.cpp
+++ b/higan/md/vdp/vdp.cpp
@@ -132,6 +132,8 @@ auto VDP::power(bool reset) -> void {
   planeB.power();
   sprite.power();
   dma.power();
+
+  psg.power(reset);
 }
 
 }

--- a/higan/md/vdp/vdp.cpp
+++ b/higan/md/vdp/vdp.cpp
@@ -42,21 +42,11 @@ auto VDP::main() -> void {
   scanline();
 
   cpu.lower(CPU::Interrupt::HorizontalBlank);
-  apu.setINT(false);
 
   if(state.vcounter == 0) {
     latch.horizontalInterruptCounter = io.horizontalInterruptCounter;
     io.vblankIRQ = false;
     cpu.lower(CPU::Interrupt::VerticalBlank);
-  }
-
-  if(state.vcounter == screenHeight()) {
-    if(io.verticalBlankInterruptEnable) {
-      io.vblankIRQ = true;
-      cpu.raise(CPU::Interrupt::VerticalBlank);
-    }
-    //todo: should only stay high for ~2573/2 clocks
-    apu.setINT(true);
   }
 
   if(state.vcounter < screenHeight()) {
@@ -74,6 +64,19 @@ auto VDP::main() -> void {
     }
 
     step(430);
+
+  } else if(state.vcounter == screenHeight()) {
+    if(io.verticalBlankInterruptEnable) {
+      io.vblankIRQ = true;
+      cpu.raise(CPU::Interrupt::VerticalBlank);
+    }
+
+    // only stay high for ~2573/2 clocks
+    apu.setINT(true);
+    step(2573/2);
+    apu.setINT(false);
+    step(1710-(2573/2));
+
   } else {
     step(1710);
   }


### PR DESCRIPTION
1) MD reset logic -- fixes various issues that arise when switching games
2) Z80 interrupt processing -- corrects music tempo in Air Buster & US SegaCD v2 BIOS
3) Z80 IRQ duration - avoids timing issues and unnecessary interrupt processing in some games
4) 68K->Z80 bus control - fixes Fatal Rewind boot & music in US SegaCD v1 BIOS
5) Z80 timing fixes - based on info published in "The Undocumented Z80 Documented" by Sean Young