### PR TITLE
sfc: Really fix automatic joypad polling, for sure.

### DIFF
--- a/higan/sfc/cpu/cpu.hpp
+++ b/higan/sfc/cpu/cpu.hpp
@@ -127,9 +127,7 @@ private:
     bool hdmaPending = 0;
     bool hdmaMode = 0;  //0 = init, 1 = run
 
-    bool autoJoypadActive = 0;
-    bool autoJoypadLatch = 0;
-    uint autoJoypadCounter = 0;
+    uint autoJoypadCounter = 33;  //state machine; 4224 / 128 = 33 (inactive)
   } status;
 
   struct IO {

--- a/higan/sfc/cpu/io.cpp
+++ b/higan/sfc/cpu/io.cpp
@@ -126,7 +126,7 @@ auto CPU::writeCPU(uint24 address, uint8 data) -> void {
 
   case 0x4200:  //NMITIMEN
     io.autoJoypadPoll = data.bit(0);
-    if(!io.autoJoypadPoll) status.autoJoypadLatch = 0;
+    if(!io.autoJoypadPoll) status.autoJoypadCounter = 33; // Disable auto-joypad read
     nmitimenUpdate(data);
     return;
 

--- a/higan/sfc/cpu/serialization.cpp
+++ b/higan/sfc/cpu/serialization.cpp
@@ -41,8 +41,6 @@ auto CPU::serialize(serializer& s) -> void {
   s.integer(status.hdmaPending);
   s.integer(status.hdmaMode);
 
-  s.integer(status.autoJoypadActive);
-  s.integer(status.autoJoypadLatch);
   s.integer(status.autoJoypadCounter);
 
   s.integer(io.wramAddress);


### PR DESCRIPTION
In commit e422ddc, Jonas Quinn updated higan's implementation of the auto-joypad-poll mode. Those fixes were ported to bsnes in commit 39c37ec, but a problem was found with the game "SpellCraft - Aspects of Valor", fixed in bsnes in commit 4f7a269. That fix was back-ported to higan in commit 44cbb88, but that change caused a regression in "Secret of Mana" (issue #170).

This commit (helpfully provided by Jonas Quinn once again) re-ports the bsnes changes back to higan, and the problems should be solved once and for all.

Fixes #170.