### PR TITLE
[MD] Fix control port writes to always set command/address bits

### DIFF
--- a/higan/md/vdp/io.cpp
+++ b/higan/md/vdp/io.cpp
@@ -151,17 +151,17 @@ auto VDP::writeControlPort(uint16 data) -> void {
     return;
   }
 
+  //command/address bits are always set here, even for register writes
+  io.command.bit(0,1) = data.bit(14,15);
+  io.address.bit(0,13) = data.bit(0,13);
+
   //command write (hi)
   if(data.bit(14,15) != 2) {
     io.commandPending = true;
-
-    io.command.bit(0,1) = data.bit(14,15);
-    io.address.bit(0,13) = data.bit(0,13);
     return;
   }
 
   //register write (d13 is ignored)
-  if(data.bit(14,15) == 2)
   switch(data.bit(8,12)) {
 
   //mode register 1


### PR DESCRIPTION
This fixes graphical corruption when starting Golden Axe II. All credit to Eke for this fix.