### PR TITLE
Fix critical undefined bit-shift length operation

### DIFF
--- a/nall/primitives/bit-range.hpp
+++ b/nall/primitives/bit-range.hpp
@@ -57,7 +57,8 @@ template<int Precision, int Lo, int Hi> struct BitRange {
   }
 
   template<typename T> auto& operator=(const T& source) {
-    target = target & ~mask | source << shift & mask;
+    type value = source;
+    target = target & ~mask | value << shift & mask;
     return *this;
   }
 
@@ -104,17 +105,20 @@ template<int Precision, int Lo, int Hi> struct BitRange {
   }
 
   template<typename T> auto& operator&=(const T& source) {
-    target = target & (~mask | source << shift & mask);
+    type value = source;
+    target = target & (~mask | value << shift & mask);
     return *this;
   }
 
   template<typename T> auto& operator^=(const T& source) {
-    target = target ^ source << shift & mask;
+    type value = source;
+    target = target ^ value << shift & mask;
     return *this;
   }
 
   template<typename T> auto& operator|=(const T& source) {
-    target = target | source << shift & mask;
+    type value = source;
+    target = target | value << shift & mask;
     return *this;
   }
 
@@ -181,7 +185,8 @@ template<typename Type, int Precision = Type::bits()> struct DynamicBitRange {
   }
 
   template<typename T> auto& operator=(const T& source) {
-    target = target & ~mask | source << shift & mask;
+    type value = source;
+    target = target & ~mask | value << shift & mask;
     return *this;
   }
 
@@ -228,17 +233,20 @@ template<typename Type, int Precision = Type::bits()> struct DynamicBitRange {
   }
 
   template<typename T> auto& operator&=(const T& source) {
-    target = target & (~mask | source << shift & mask);
+    type value = source;
+    target = target & (~mask | value << shift & mask);
     return *this;
   }
 
   template<typename T> auto& operator^=(const T& source) {
-    target = target ^ source << shift & mask;
+    type value = source;
+    target = target ^ value << shift & mask;
     return *this;
   }
 
   template<typename T> auto& operator|=(const T& source) {
-    target = target | source << shift & mask;
+    type value = source;
+    target = target | value << shift & mask;
     return *this;
   }
 


### PR DESCRIPTION
Natural/Integer<T>.bit() (BitRange) was shifting by whatever type the source was to match the target bit length.
But this breaks when the target type is u64/s64 and the source type is u32/s32 or smaller. Shifting by >=32 becomes undefined behavior.
We have to cast the input source to the target type first, so that the source<<shift result is valid.
This is safe here regardless of source's signedness, because it's only used in =, &=, ^=, |= operations.