### PR TITLE
gba: memory.disable is actually memory.biosSwap

### DIFF
--- a/higan/gba/cpu/bus.cpp
+++ b/higan/gba/cpu/bus.cpp
@@ -6,6 +6,10 @@ auto CPU::get(uint mode, uint32 addr) -> uint32 {
   uint clocks = _wait(mode, addr);
   uint word = pipeline.fetch.instruction;
 
+  if(memory.biosSwap && addr < 0x0400'0000) {
+    addr ^= 0x0200'0000;
+  }
+
   if(addr >= 0x1000'0000) {
     prefetchStep(clocks);
   } else if(addr & 0x0800'0000) {
@@ -38,6 +42,10 @@ auto CPU::get(uint mode, uint32 addr) -> uint32 {
 auto CPU::set(uint mode, uint32 addr, uint32 word) -> void {
   uint clocks = _wait(mode, addr);
 
+  if(memory.biosSwap && addr < 0x0400'0000) {
+    addr ^= 0x0200'0000;
+  }
+
   if(addr >= 0x1000'0000) {
     prefetchStep(clocks);
   } else if(addr & 0x0800'0000) {
@@ -46,7 +54,7 @@ auto CPU::set(uint mode, uint32 addr, uint32 word) -> void {
     cartridge.write(mode, addr, word);
   } else {
     prefetchStep(clocks);
-         if(addr  < 0x0200'0000);
+         if(addr  < 0x0200'0000) bios.write(mode, addr, word);
     else if(addr  < 0x0300'0000) writeEWRAM(mode, addr, word);
     else if(addr  < 0x0400'0000) writeIWRAM(mode, addr, word);
     else if(addr >= 0x0700'0000) ppu.writeOAM(mode, addr, word);

--- a/higan/gba/cpu/cpu.hpp
+++ b/higan/gba/cpu/cpu.hpp
@@ -202,7 +202,7 @@ struct CPU : ARM7TDMI, Thread, IO {
   } wait;
 
   struct Memory {
-    uint1 disable;
+    uint1 biosSwap;
     uint3 unknown1;
     uint1 ewram = 1;
     uint4 ewramWait = 13;

--- a/higan/gba/cpu/io.cpp
+++ b/higan/gba/cpu/io.cpp
@@ -212,7 +212,7 @@ auto CPU::readIO(uint32 addr) -> uint8 {
 
   //MEMCNT_L
   case 0x0400'0800: return (
-    memory.disable  << 0
+    memory.biosSwap << 0
   | memory.unknown1 << 1
   | memory.ewram    << 5
   );
@@ -439,7 +439,7 @@ auto CPU::writeIO(uint32 addr, uint8 data) -> void {
   //MEMCNT_L
   //MEMCNT_H
   case 0x0400'0800:
-    memory.disable  = data.bit(0);
+    memory.biosSwap = data.bit(0);
     memory.unknown1 = data.bit(1,3);
     memory.ewram    = data.bit(5);
     return;

--- a/higan/gba/cpu/memory.cpp
+++ b/higan/gba/cpu/memory.cpp
@@ -1,6 +1,4 @@
 auto CPU::readIWRAM(uint mode, uint32 addr) -> uint32 {
-  if(memory.disable) return cpu.pipeline.fetch.instruction;
-
   if(mode & Word) return readIWRAM(Half, addr &~ 2) << 0 | readIWRAM(Half, addr | 2) << 16;
   if(mode & Half) return readIWRAM(Byte, addr &~ 1) << 0 | readIWRAM(Byte, addr | 1) <<  8;
 
@@ -8,8 +6,6 @@ auto CPU::readIWRAM(uint mode, uint32 addr) -> uint32 {
 }
 
 auto CPU::writeIWRAM(uint mode, uint32 addr, uint32 word) -> void {
-  if(memory.disable) return;
-
   if(mode & Word) {
     writeIWRAM(Half, addr &~2, word >>  0);
     writeIWRAM(Half, addr | 2, word >> 16);
@@ -26,7 +22,6 @@ auto CPU::writeIWRAM(uint mode, uint32 addr, uint32 word) -> void {
 }
 
 auto CPU::readEWRAM(uint mode, uint32 addr) -> uint32 {
-  if(memory.disable) return cpu.pipeline.fetch.instruction;
   if(!memory.ewram) return readIWRAM(mode, addr);
 
   if(mode & Word) return readEWRAM(Half, addr &~ 2) << 0 | readEWRAM(Half, addr | 2) << 16;
@@ -36,7 +31,6 @@ auto CPU::readEWRAM(uint mode, uint32 addr) -> uint32 {
 }
 
 auto CPU::writeEWRAM(uint mode, uint32 addr, uint32 word) -> void {
-  if(memory.disable) return;
   if(!memory.ewram) return writeIWRAM(mode, addr, word);
 
   if(mode & Word) {

--- a/higan/gba/cpu/serialization.cpp
+++ b/higan/gba/cpu/serialization.cpp
@@ -87,7 +87,7 @@ auto CPU::serialize(serializer& s) -> void {
   s.integer(wait.prefetch);
   s.integer(wait.gameType);
 
-  s.integer(memory.disable);
+  s.integer(memory.biosSwap);
   s.integer(memory.unknown1);
   s.integer(memory.ewram);
   s.integer(memory.ewramWait);

--- a/higan/gba/system/bios.cpp
+++ b/higan/gba/system/bios.cpp
@@ -10,12 +10,15 @@ BIOS::~BIOS() {
 }
 
 auto BIOS::read(uint mode, uint32 addr) -> uint32 {
+  addr &= 0x01ff'ffff;
+
   //unmapped memory
   if(addr >= 0x0000'4000) return cpu.pipeline.fetch.instruction;  //0000'4000-01ff'ffff
 
   //GBA BIOS is read-protected; only the BIOS itself can read its own memory
   //when accessed elsewhere; this should return the last value read by the BIOS program
-  if(cpu.processor.r15 >= 0x0000'4000) return mdr;
+  if(!cpu.memory.biosSwap && cpu.processor.r15 >= 0x0000'4000) return mdr;
+  if(cpu.memory.biosSwap && (cpu.processor.r15 < 0x0200'0000 || cpu.processor.r15 >= 0x0200'4000)) return mdr;
 
   if(mode & Word) return mdr = read(Half, addr &~ 2) << 0 | read(Half, addr | 2) << 16;
   if(mode & Half) return mdr = read(Byte, addr &~ 1) << 0 | read(Byte, addr | 1) <<  8;


### PR DESCRIPTION
The reason that IWRAM and EWRAM appear to be disabled is because they were swapped with the BIOS.

(Thanks to kevtris for disclosure of this behaviour.)