### PR TITLE
hiro: Force Gtk3 to use X11 backend

### DIFF
--- a/hiro/gtk/application.cpp
+++ b/hiro/gtk/application.cpp
@@ -82,6 +82,8 @@ auto pApplication::state() -> State& {
 
 auto pApplication::initialize() -> void {
   #if defined(DISPLAY_XORG)
+  // If running on Wayland, force usage of XWayland
+  setenv("GDK_BACKEND", "x11", 1);
   state().display = XOpenDisplay(nullptr);
   state().screenSaverXDG = (bool)execute("xdg-screensaver", "--version").output.find("xdg-screensaver");
 


### PR DESCRIPTION
when running with Wayland higan crashes with the following error because GDK backend was not properly set:
```
(higan:2515): Gdk-CRITICAL **: 08:23:32.132: gdk_x11_window_get_xid: assertion 'GDK_IS_X11_WINDOW (window)' failed
X Error of failed request:  BadWindow (invalid Window parameter)
```

The same fix in ares repository: https://github.com/ares-emulator/ares/pull/9/commits/805d4bd3b1ba7bfa620813f7331f6993aa1d2383

Tested on Ubuntu 22.04&23.04, Fedora 37&38.