### PR TITLE
Fix for SA-1 side DMA to BWRAM banks 0x41+

### DIFF
--- a/higan/sfc/coprocessor/sa1/dma.cpp
+++ b/higan/sfc/coprocessor/sa1/dma.cpp
@@ -3,7 +3,7 @@ auto SA1::dmaNormal() -> void {
   while(io.dtc--) {
     uint8 data = r.mdr;
     uint24 source = io.dsa++;
-    uint16 target = io.dda++;
+    uint24 target = io.dda++;
 
     if(io.sd == DMA::SourceROM && io.dd == DMA::DestBWRAM) {
       step();


### PR DESCRIPTION
This is not my discovery, I am simply mirroring the pull request submitted to ares (and already merged) as well as to bsnes (still open at this time). 

DDA was incorrectly capped at 16 bits instead of 24, making DMAs to
BWRAM banks 0x41-43 be sent to the corresponding spot in 0x40 instead.
See [the corresponding bug in
bsnes](https://github.com/bsnes-emu/bsnes/issues/309) for some more
context.